### PR TITLE
[Feat] 월별 제한 인원 설정 기능 추가

### DIFF
--- a/src/main/java/com/better/CommuteMate/application/schedule/MonthlyScheduleLimitService.java
+++ b/src/main/java/com/better/CommuteMate/application/schedule/MonthlyScheduleLimitService.java
@@ -1,0 +1,49 @@
+package com.better.CommuteMate.application.schedule;
+
+import com.better.CommuteMate.domain.schedule.entity.MonthlyScheduleLimit;
+import com.better.CommuteMate.domain.schedule.repository.MonthlyScheduleLimitRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MonthlyScheduleLimitService {
+
+    private final MonthlyScheduleLimitRepository monthlyScheduleLimitRepository;
+
+    @Transactional
+    public MonthlyScheduleLimit setMonthlyLimit(Integer scheduleYear, Integer scheduleMonth, Integer maxConcurrent, Integer userId) {
+        Optional<MonthlyScheduleLimit> existingLimit = monthlyScheduleLimitRepository.findByScheduleYearAndScheduleMonth(scheduleYear, scheduleMonth);
+
+        if (existingLimit.isPresent()) {
+            // 업데이트
+            MonthlyScheduleLimit limit = existingLimit.get();
+            limit.setMaxConcurrent(maxConcurrent);
+            limit.setUpdatedBy(userId);
+            return monthlyScheduleLimitRepository.save(limit);
+        } else {
+            // 신규 생성
+            MonthlyScheduleLimit newLimit = MonthlyScheduleLimit.builder()
+                    .scheduleYear(scheduleYear)
+                    .scheduleMonth(scheduleMonth)
+                    .maxConcurrent(maxConcurrent)
+                    .createdBy(userId)
+                    .updatedBy(userId)
+                    .build();
+            return monthlyScheduleLimitRepository.save(newLimit);
+        }
+    }
+
+    public Optional<MonthlyScheduleLimit> getMonthlyLimit(Integer scheduleYear, Integer scheduleMonth) {
+        return monthlyScheduleLimitRepository.findByScheduleYearAndScheduleMonth(scheduleYear, scheduleMonth);
+    }
+
+    public List<MonthlyScheduleLimit> getAllMonthlyLimits() {
+        return monthlyScheduleLimitRepository.findAll();
+    }
+}

--- a/src/main/java/com/better/CommuteMate/controller/admin/AdminScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/controller/admin/AdminScheduleController.java
@@ -1,0 +1,74 @@
+package com.better.CommuteMate.controller.admin;
+
+import com.better.CommuteMate.application.schedule.MonthlyScheduleLimitService;
+import com.better.CommuteMate.controller.admin.dtos.MonthlyLimitResponse;
+import com.better.CommuteMate.controller.admin.dtos.MonthlyLimitsResponse;
+import com.better.CommuteMate.controller.admin.dtos.SetMonthlyLimitRequest;
+import com.better.CommuteMate.domain.schedule.entity.MonthlyScheduleLimit;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/v1/admin/schedule")
+@RequiredArgsConstructor
+public class AdminScheduleController {
+
+    private final MonthlyScheduleLimitService monthlyScheduleLimitService;
+
+    // 월별 스케줄 제한 설정
+    @PostMapping("/monthly-limit")
+    public ResponseEntity<Response> setMonthlyLimit(
+            @RequestBody SetMonthlyLimitRequest request,
+            @RequestHeader(value = "userId", defaultValue = "1") Integer userId) {
+        // @RequestHeader userId는 추후 인증로직이 추가되면 변경될 예정
+
+        MonthlyScheduleLimit result = monthlyScheduleLimitService.setMonthlyLimit(
+                request.scheduleYear(),
+                request.scheduleMonth(),
+                request.maxConcurrent(),
+                userId
+        );
+
+        return ResponseEntity.status(HttpStatus.OK).body(Response.of(
+                true,
+                "월별 스케줄 제한이 설정되었습니다.",
+                MonthlyLimitResponse.from(result)
+        ));
+    }
+
+    // 특정 월의 스케줄 제한 조회
+    @GetMapping("/monthly-limit/{year}/{month}")
+    public ResponseEntity<Response> getMonthlyLimit(
+            @PathVariable Integer year,
+            @PathVariable Integer month) {
+
+        return monthlyScheduleLimitService.getMonthlyLimit(year, month)
+                .map(limit -> ResponseEntity.ok(Response.of(
+                        true,
+                        "월별 스케줄 제한을 조회했습니다.",
+                        MonthlyLimitResponse.from(limit)
+                )))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).body(Response.of(
+                        false,
+                        "해당 월의 스케줄 제한 설정을 찾을 수 없습니다.",
+                        null
+                )));
+    }
+
+    // 모든 월별 스케줄 제한 조회
+    @GetMapping("/monthly-limits")
+    public ResponseEntity<Response> getAllMonthlyLimits() {
+        List<MonthlyScheduleLimit> limits = monthlyScheduleLimitService.getAllMonthlyLimits();
+
+        return ResponseEntity.ok(Response.of(
+                true,
+                "모든 월별 스케줄 제한을 조회했습니다.",
+                MonthlyLimitsResponse.from(limits)
+        ));
+    }
+}

--- a/src/main/java/com/better/CommuteMate/controller/admin/dtos/MonthlyLimitResponse.java
+++ b/src/main/java/com/better/CommuteMate/controller/admin/dtos/MonthlyLimitResponse.java
@@ -1,0 +1,24 @@
+package com.better.CommuteMate.controller.admin.dtos;
+
+import com.better.CommuteMate.domain.schedule.entity.MonthlyScheduleLimit;
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MonthlyLimitResponse extends ResponseDetail {
+    private final Integer scheduleYear;
+    private final Integer scheduleMonth;
+    private final Integer maxConcurrent;
+
+    public static MonthlyLimitResponse from(MonthlyScheduleLimit limit) {
+        return MonthlyLimitResponse.builder()
+                .scheduleYear(limit.getScheduleYear())
+                .scheduleMonth(limit.getScheduleMonth())
+                .maxConcurrent(limit.getMaxConcurrent())
+                .build();
+    }
+}

--- a/src/main/java/com/better/CommuteMate/controller/admin/dtos/MonthlyLimitsResponse.java
+++ b/src/main/java/com/better/CommuteMate/controller/admin/dtos/MonthlyLimitsResponse.java
@@ -1,0 +1,38 @@
+package com.better.CommuteMate.controller.admin.dtos;
+
+import com.better.CommuteMate.domain.schedule.entity.MonthlyScheduleLimit;
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class MonthlyLimitsResponse extends ResponseDetail {
+    private final List<MonthlyLimitItem> limits;
+
+    @Getter
+    @Builder
+    public static class MonthlyLimitItem {
+        private final Integer year;
+        private final Integer month;
+        private final Integer maxConcurrent;
+
+        public static MonthlyLimitItem from(MonthlyScheduleLimit limit) {
+            return MonthlyLimitItem.builder()
+                    .year(limit.getScheduleYear())
+                    .month(limit.getScheduleMonth())
+                    .maxConcurrent(limit.getMaxConcurrent())
+                    .build();
+        }
+    }
+
+    public static MonthlyLimitsResponse from(List<MonthlyScheduleLimit> limits) {
+        return MonthlyLimitsResponse.builder()
+                .limits(limits.stream().map(MonthlyLimitItem::from).toList())
+                .build();
+    }
+}

--- a/src/main/java/com/better/CommuteMate/controller/admin/dtos/SetMonthlyLimitRequest.java
+++ b/src/main/java/com/better/CommuteMate/controller/admin/dtos/SetMonthlyLimitRequest.java
@@ -1,0 +1,8 @@
+package com.better.CommuteMate.controller.admin.dtos;
+
+public record SetMonthlyLimitRequest(
+        Integer scheduleYear,
+        Integer scheduleMonth,
+        Integer maxConcurrent
+) {
+}

--- a/src/main/java/com/better/CommuteMate/domain/schedule/entity/MonthlyScheduleLimit.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/entity/MonthlyScheduleLimit.java
@@ -1,0 +1,54 @@
+package com.better.CommuteMate.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "monthly_schedule_limit",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"schedule_year", "schedule_month"}))
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MonthlyScheduleLimit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "limit_id", nullable = false)
+    private Integer limitId;
+
+    @Column(name = "schedule_year", nullable = false)
+    private Integer scheduleYear;
+
+    @Column(name = "schedule_month", nullable = false)
+    private Integer scheduleMonth;
+
+    @Column(name = "max_concurrent", nullable = false)
+    private Integer maxConcurrent;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", nullable = false, updatable = false)
+    private Integer createdBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by")
+    private Integer updatedBy;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/better/CommuteMate/domain/schedule/repository/MonthlyScheduleLimitRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/repository/MonthlyScheduleLimitRepository.java
@@ -1,0 +1,13 @@
+package com.better.CommuteMate.domain.schedule.repository;
+
+import com.better.CommuteMate.domain.schedule.entity.MonthlyScheduleLimit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MonthlyScheduleLimitRepository extends JpaRepository<MonthlyScheduleLimit, Integer> {
+
+    Optional<MonthlyScheduleLimit> findByScheduleYearAndScheduleMonth(Integer scheduleYear, Integer scheduleMonth);
+}

--- a/src/test/java/com/better/CommuteMate/controller/admin/AdminScheduleControllerTest.java
+++ b/src/test/java/com/better/CommuteMate/controller/admin/AdminScheduleControllerTest.java
@@ -1,0 +1,214 @@
+package com.better.CommuteMate.controller.admin;
+
+import com.better.CommuteMate.application.schedule.MonthlyScheduleLimitService;
+import com.better.CommuteMate.controller.admin.dtos.SetMonthlyLimitRequest;
+import com.better.CommuteMate.domain.schedule.entity.MonthlyScheduleLimit;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminScheduleController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AdminScheduleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MonthlyScheduleLimitService monthlyScheduleLimitService;
+
+    @Test
+    @DisplayName("POST /api/v1/admin/schedule/monthly-limit - 신규 월별 제한 설정 성공")
+    void setMonthlyLimit_NewLimit_Success() throws Exception {
+        // Given
+        SetMonthlyLimitRequest request = new SetMonthlyLimitRequest(2025, 10, 6);
+
+        MonthlyScheduleLimit savedLimit = MonthlyScheduleLimit.builder()
+                .limitId(1)
+                .scheduleYear(2025)
+                .scheduleMonth(10)
+                .maxConcurrent(6)
+                .createdBy(1)
+                .updatedBy(1)
+                .build();
+
+        when(monthlyScheduleLimitService.setMonthlyLimit(anyInt(), anyInt(), anyInt(), anyInt()))
+                .thenReturn(savedLimit);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/admin/schedule/monthly-limit")
+                        .header("userId", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value("월별 스케줄 제한이 설정되었습니다."))
+                .andExpect(jsonPath("$.details.scheduleYear").value(2025))
+                .andExpect(jsonPath("$.details.scheduleMonth").value(10))
+                .andExpect(jsonPath("$.details.maxConcurrent").value(6));
+
+        verify(monthlyScheduleLimitService, times(1))
+                .setMonthlyLimit(2025, 10, 6, 1);
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/admin/schedule/monthly-limit - 기존 월별 제한 업데이트 성공")
+    void setMonthlyLimit_UpdateExisting_Success() throws Exception {
+        // Given
+        SetMonthlyLimitRequest request = new SetMonthlyLimitRequest(2025, 10, 8);
+
+        MonthlyScheduleLimit updatedLimit = MonthlyScheduleLimit.builder()
+                .limitId(1)
+                .scheduleYear(2025)
+                .scheduleMonth(10)
+                .maxConcurrent(8)
+                .createdBy(1)
+                .updatedBy(1)
+                .build();
+
+        when(monthlyScheduleLimitService.setMonthlyLimit(anyInt(), anyInt(), anyInt(), anyInt()))
+                .thenReturn(updatedLimit);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/admin/schedule/monthly-limit")
+                        .header("userId", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value("월별 스케줄 제한이 설정되었습니다."))
+                .andExpect(jsonPath("$.details.maxConcurrent").value(8));
+
+        verify(monthlyScheduleLimitService, times(1))
+                .setMonthlyLimit(2025, 10, 8, 1);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/admin/schedule/monthly-limit/{year}/{month} - 데이터 존재 시 200 OK")
+    void getMonthlyLimit_DataExists_Returns200() throws Exception {
+        // Given
+        Integer year = 2025;
+        Integer month = 10;
+
+        MonthlyScheduleLimit limit = MonthlyScheduleLimit.builder()
+                .limitId(1)
+                .scheduleYear(year)
+                .scheduleMonth(month)
+                .maxConcurrent(6)
+                .createdBy(1)
+                .updatedBy(1)
+                .build();
+
+        when(monthlyScheduleLimitService.getMonthlyLimit(year, month))
+                .thenReturn(Optional.of(limit));
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/admin/schedule/monthly-limit/{year}/{month}", year, month))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value("월별 스케줄 제한을 조회했습니다."))
+                .andExpect(jsonPath("$.details.scheduleYear").value(2025))
+                .andExpect(jsonPath("$.details.scheduleMonth").value(10))
+                .andExpect(jsonPath("$.details.maxConcurrent").value(6));
+
+        verify(monthlyScheduleLimitService, times(1)).getMonthlyLimit(year, month);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/admin/schedule/monthly-limit/{year}/{month} - 데이터 없을 시 404 NOT_FOUND")
+    void getMonthlyLimit_DataNotExists_Returns404() throws Exception {
+        // Given
+        Integer year = 2025;
+        Integer month = 11;
+
+        when(monthlyScheduleLimitService.getMonthlyLimit(year, month))
+                .thenReturn(Optional.empty());
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/admin/schedule/monthly-limit/{year}/{month}", year, month))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.message").value("해당 월의 스케줄 제한 설정을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.details").isEmpty());
+
+        verify(monthlyScheduleLimitService, times(1)).getMonthlyLimit(year, month);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/admin/schedule/monthly-limits - 모든 데이터 조회 성공")
+    void getAllMonthlyLimits_Success() throws Exception {
+        // Given
+        MonthlyScheduleLimit limit1 = MonthlyScheduleLimit.builder()
+                .limitId(1)
+                .scheduleYear(2025)
+                .scheduleMonth(10)
+                .maxConcurrent(6)
+                .createdBy(1)
+                .updatedBy(1)
+                .build();
+
+        MonthlyScheduleLimit limit2 = MonthlyScheduleLimit.builder()
+                .limitId(2)
+                .scheduleYear(2025)
+                .scheduleMonth(11)
+                .maxConcurrent(5)
+                .createdBy(1)
+                .updatedBy(1)
+                .build();
+
+        List<MonthlyScheduleLimit> limits = List.of(limit1, limit2);
+        when(monthlyScheduleLimitService.getAllMonthlyLimits()).thenReturn(limits);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/admin/schedule/monthly-limits"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value("모든 월별 스케줄 제한을 조회했습니다."))
+                .andExpect(jsonPath("$.details.limits").isArray())
+                .andExpect(jsonPath("$.details.limits.length()").value(2))
+                .andExpect(jsonPath("$.details.limits[0].scheduleYear").value(2025))
+                .andExpect(jsonPath("$.details.limits[0].scheduleMonth").value(10))
+                .andExpect(jsonPath("$.details.limits[0].maxConcurrent").value(6))
+                .andExpect(jsonPath("$.details.limits[1].scheduleYear").value(2025))
+                .andExpect(jsonPath("$.details.limits[1].scheduleMonth").value(11))
+                .andExpect(jsonPath("$.details.limits[1].maxConcurrent").value(5));
+
+        verify(monthlyScheduleLimitService, times(1)).getAllMonthlyLimits();
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/admin/schedule/monthly-limits - 빈 리스트 반환")
+    void getAllMonthlyLimits_EmptyList() throws Exception {
+        // Given
+        when(monthlyScheduleLimitService.getAllMonthlyLimits()).thenReturn(List.of());
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/admin/schedule/monthly-limits"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value("모든 월별 스케줄 제한을 조회했습니다."))
+                .andExpect(jsonPath("$.details.limits").isArray())
+                .andExpect(jsonPath("$.details.limits.length()").value(0));
+
+        verify(monthlyScheduleLimitService, times(1)).getAllMonthlyLimits();
+    }
+}


### PR DESCRIPTION
## 월별 제한 인원 기능

2025.10. 의 근무 하루 제한 인원이 한시적으로 6명으로 바뀜. 
이를 보고, 모든 월이 같은 근무 제한 인원이 아닐 수도 있다는 판단, 월별 근무 제한 인원 설정 기능 추가.

## Entity
year과 month 엔티티를 활용한 monthly_schedule_limit 테이블 생성.
이를 활용해 월별 근무 인원 제한 저장 가능.
만일 설정 안되어 있는 경우, 환경 변수로 설정한 값이 기본값이 됨.

