### PR TITLE
[Fix] MonthlyScheduleLimitCommand 도입 및 스케줄 제한 설정 개선

### DIFF
--- a/src/main/java/com/better/CommuteMate/application/schedule/MonthlyScheduleLimitService.java
+++ b/src/main/java/com/better/CommuteMate/application/schedule/MonthlyScheduleLimitService.java
@@ -1,5 +1,6 @@
 package com.better.CommuteMate.application.schedule;
 
+import com.better.CommuteMate.application.schedule.dtos.MonthlyScheduleLimitCommand;
 import com.better.CommuteMate.domain.schedule.entity.MonthlyScheduleLimit;
 import com.better.CommuteMate.domain.schedule.repository.MonthlyScheduleLimitRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,23 +18,24 @@ public class MonthlyScheduleLimitService {
     private final MonthlyScheduleLimitRepository monthlyScheduleLimitRepository;
 
     @Transactional
-    public MonthlyScheduleLimit setMonthlyLimit(Integer scheduleYear, Integer scheduleMonth, Integer maxConcurrent, Integer userId) {
-        Optional<MonthlyScheduleLimit> existingLimit = monthlyScheduleLimitRepository.findByScheduleYearAndScheduleMonth(scheduleYear, scheduleMonth);
+    public MonthlyScheduleLimit setMonthlyLimit(MonthlyScheduleLimitCommand command) {
+        Optional<MonthlyScheduleLimit> existingLimit = monthlyScheduleLimitRepository
+                .findByScheduleYearAndScheduleMonth(command.scheduleYear(), command.scheduleMonth());
 
         if (existingLimit.isPresent()) {
             // 업데이트
             MonthlyScheduleLimit limit = existingLimit.get();
-            limit.setMaxConcurrent(maxConcurrent);
-            limit.setUpdatedBy(userId);
+            limit.setMaxConcurrent(command.maxConcurrent());
+            limit.setUpdatedBy(command.userId());
             return monthlyScheduleLimitRepository.save(limit);
         } else {
             // 신규 생성
             MonthlyScheduleLimit newLimit = MonthlyScheduleLimit.builder()
-                    .scheduleYear(scheduleYear)
-                    .scheduleMonth(scheduleMonth)
-                    .maxConcurrent(maxConcurrent)
-                    .createdBy(userId)
-                    .updatedBy(userId)
+                    .scheduleYear(command.scheduleYear())
+                    .scheduleMonth(command.scheduleMonth())
+                    .maxConcurrent(command.maxConcurrent())
+                    .createdBy(command.userId())
+                    .updatedBy(command.userId())
                     .build();
             return monthlyScheduleLimitRepository.save(newLimit);
         }

--- a/src/main/java/com/better/CommuteMate/application/schedule/dtos/MonthlyScheduleLimitCommand.java
+++ b/src/main/java/com/better/CommuteMate/application/schedule/dtos/MonthlyScheduleLimitCommand.java
@@ -1,0 +1,19 @@
+package com.better.CommuteMate.application.schedule.dtos;
+
+public record MonthlyScheduleLimitCommand(
+        Integer scheduleYear,
+        Integer scheduleMonth,
+        Integer maxConcurrent,
+        Integer userId) {
+    public static MonthlyScheduleLimitCommand from(
+            Integer scheduleYear,
+            Integer scheduleMonth,
+            Integer maxConcurrent,
+            Integer userId) {
+        return new MonthlyScheduleLimitCommand(
+                scheduleYear,
+                scheduleMonth, 
+                maxConcurrent,
+                userId);
+    }
+}

--- a/src/main/java/com/better/CommuteMate/controller/admin/AdminScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/controller/admin/AdminScheduleController.java
@@ -1,6 +1,7 @@
 package com.better.CommuteMate.controller.admin;
 
 import com.better.CommuteMate.application.schedule.MonthlyScheduleLimitService;
+import com.better.CommuteMate.application.schedule.dtos.MonthlyScheduleLimitCommand;
 import com.better.CommuteMate.controller.admin.dtos.MonthlyLimitResponse;
 import com.better.CommuteMate.controller.admin.dtos.MonthlyLimitsResponse;
 import com.better.CommuteMate.controller.admin.dtos.SetMonthlyLimitRequest;
@@ -28,10 +29,12 @@ public class AdminScheduleController {
         // @RequestHeader userId는 추후 인증로직이 추가되면 변경될 예정
 
         MonthlyScheduleLimit result = monthlyScheduleLimitService.setMonthlyLimit(
-                request.scheduleYear(),
-                request.scheduleMonth(),
-                request.maxConcurrent(),
-                userId
+                MonthlyScheduleLimitCommand.from(
+                        request.scheduleYear(),
+                        request.scheduleMonth(),
+                        request.maxConcurrent(),
+                        userId
+                )
         );
 
         return ResponseEntity.status(HttpStatus.OK).body(Response.of(

--- a/src/test/java/com/better/CommuteMate/application/schedule/ScheduleValidatorTest.java
+++ b/src/test/java/com/better/CommuteMate/application/schedule/ScheduleValidatorTest.java
@@ -2,7 +2,7 @@ package com.better.CommuteMate.application.schedule;
 
 import com.better.CommuteMate.application.schedule.dtos.WorkScheduleCommand;
 import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
-import com.better.CommuteMate.domain.schedule.entity.WorkScheduleStatusCode;
+import com.better.CommuteMate.domain.schedule.repository.MonthlyScheduleLimitRepository;
 import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
 import com.better.CommuteMate.domain.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,9 +18,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +31,9 @@ class ScheduleValidatorTest {
     @Mock
     private WorkSchedulesRepository workSchedulesRepository;
 
+    @Mock
+    private MonthlyScheduleLimitRepository monthlyScheduleLimitRepository;
+
     @InjectMocks
     private ScheduleValidator scheduleValidator;
 
@@ -36,7 +41,11 @@ class ScheduleValidatorTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(scheduleValidator, "MAX_CONCURRENT_SCHEDULES", 3);
+        ReflectionTestUtils.setField(scheduleValidator, "DEFAULT_MAX_CONCURRENT_SCHEDULES", 3);
+
+        // 월별 제한이 없는 경우 기본값(3) 사용하도록 모킹
+        when(monthlyScheduleLimitRepository.findByScheduleYearAndScheduleMonth(anyInt(), anyInt()))
+                .thenReturn(Optional.empty());
 
         testUser = User.builder()
                 .email("test@example.com")

--- a/src/test/java/com/better/CommuteMate/controller/admin/AdminScheduleControllerTest.java
+++ b/src/test/java/com/better/CommuteMate/controller/admin/AdminScheduleControllerTest.java
@@ -1,6 +1,7 @@
 package com.better.CommuteMate.controller.admin;
 
 import com.better.CommuteMate.application.schedule.MonthlyScheduleLimitService;
+import com.better.CommuteMate.application.schedule.dtos.MonthlyScheduleLimitCommand;
 import com.better.CommuteMate.controller.admin.dtos.SetMonthlyLimitRequest;
 import com.better.CommuteMate.domain.schedule.entity.MonthlyScheduleLimit;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,7 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -51,7 +52,7 @@ class AdminScheduleControllerTest {
                 .updatedBy(1)
                 .build();
 
-        when(monthlyScheduleLimitService.setMonthlyLimit(anyInt(), anyInt(), anyInt(), anyInt()))
+        when(monthlyScheduleLimitService.setMonthlyLimit(any(MonthlyScheduleLimitCommand.class)))
                 .thenReturn(savedLimit);
 
         // When & Then
@@ -67,7 +68,7 @@ class AdminScheduleControllerTest {
                 .andExpect(jsonPath("$.details.maxConcurrent").value(6));
 
         verify(monthlyScheduleLimitService, times(1))
-                .setMonthlyLimit(2025, 10, 6, 1);
+                .setMonthlyLimit(any(MonthlyScheduleLimitCommand.class));
     }
 
     @Test
@@ -85,7 +86,7 @@ class AdminScheduleControllerTest {
                 .updatedBy(1)
                 .build();
 
-        when(monthlyScheduleLimitService.setMonthlyLimit(anyInt(), anyInt(), anyInt(), anyInt()))
+        when(monthlyScheduleLimitService.setMonthlyLimit(any(MonthlyScheduleLimitCommand.class)))
                 .thenReturn(updatedLimit);
 
         // When & Then
@@ -99,7 +100,7 @@ class AdminScheduleControllerTest {
                 .andExpect(jsonPath("$.details.maxConcurrent").value(8));
 
         verify(monthlyScheduleLimitService, times(1))
-                .setMonthlyLimit(2025, 10, 8, 1);
+                .setMonthlyLimit(any(MonthlyScheduleLimitCommand.class));
     }
 
     @Test
@@ -185,11 +186,11 @@ class AdminScheduleControllerTest {
                 .andExpect(jsonPath("$.message").value("모든 월별 스케줄 제한을 조회했습니다."))
                 .andExpect(jsonPath("$.details.limits").isArray())
                 .andExpect(jsonPath("$.details.limits.length()").value(2))
-                .andExpect(jsonPath("$.details.limits[0].scheduleYear").value(2025))
-                .andExpect(jsonPath("$.details.limits[0].scheduleMonth").value(10))
+                .andExpect(jsonPath("$.details.limits[0].year").value(2025))
+                .andExpect(jsonPath("$.details.limits[0].month").value(10))
                 .andExpect(jsonPath("$.details.limits[0].maxConcurrent").value(6))
-                .andExpect(jsonPath("$.details.limits[1].scheduleYear").value(2025))
-                .andExpect(jsonPath("$.details.limits[1].scheduleMonth").value(11))
+                .andExpect(jsonPath("$.details.limits[1].year").value(2025))
+                .andExpect(jsonPath("$.details.limits[1].month").value(11))
                 .andExpect(jsonPath("$.details.limits[1].maxConcurrent").value(5));
 
         verify(monthlyScheduleLimitService, times(1)).getAllMonthlyLimits();


### PR DESCRIPTION
월별 스케줄 제한 설정의 일관성과 유지보수성을 향상시키기 위해 `MonthlyScheduleLimitCommand` DTO를 도입하고 관련 코드를 리팩토링합니다.

**변경 사항:**
*   `MonthlyScheduleLimitCommand` 레코드를 추가하여 월별 스케줄 제한 설정을 위한 파라미터(년도, 월, 최대 동시성, 사용자 ID)를 하나의 객체로 캡슐화합니다.
*   `MonthlyScheduleLimitService`의 `setMonthlyLimit` 메서드가 `MonthlyScheduleLimitCommand` 객체를 인자로 받도록 수정하여 메서드 시그니처를 간소화하고 코드의 응집도를 높입니다.
*   `AdminScheduleController`에서 월별 스케줄 제한 설정 요청 처리 시, `MonthlyScheduleLimitCommand`를 생성하여 서비스 계층으로 전달하도록 로직을 업데이트합니다.
*   변경된 DTO 구조에 맞춰 관련 테스트 코드(Controller, Service)를 수정하여 새로운 커맨드 패턴 사용을 검증합니다.
*   `ScheduleValidatorTest`에 `MonthlyScheduleLimitRepository`를 모킹하여 월별 스케줄 제한 설정이 동적으로 적용될 수 있는 기반을 마련합니다.