### PR TITLE
feat: 신청 기간 설정 엔드포인트 구현 및 기본값 자동 설정

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/schedule/entity/MonthlyScheduleConfig.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/entity/MonthlyScheduleConfig.java
@@ -29,10 +29,10 @@ public class MonthlyScheduleConfig {
     @Column(name = "max_concurrent", nullable = false)
     private Integer maxConcurrent;
 
-    @Column(name = "apply_start_time", nullable = true)
+    @Column(name = "apply_start_time", nullable = false)
     private LocalDateTime applyStartTime;
 
-    @Column(name = "apply_end_time", nullable = true)
+    @Column(name = "apply_end_time", nullable = false)
     private LocalDateTime applyEndTime;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/better/CommuteMate/schedule/application/MonthlyScheduleConfigService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/MonthlyScheduleConfigService.java
@@ -12,8 +12,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,17 +37,13 @@ public class MonthlyScheduleConfigService {
             limit.setUpdatedBy(command.userId());
             return monthlyScheduleConfigRepository.save(limit);
         } else {
-            // 신규 생성 - 기본 신청 기간 설정
-            // 신청 기간: 전달 23일 00:00 ~ 27일 00:00
-            LocalDateTime applyStartTime = getDefaultApplyStartTime(command.scheduleYear(), command.scheduleMonth());
-            LocalDateTime applyEndTime = getDefaultApplyEndTime(command.scheduleYear(), command.scheduleMonth());
-
+            // 신규 생성 - Command에서 계산된 기본 신청 기간 사용
             MonthlyScheduleConfig newLimit = MonthlyScheduleConfig.builder()
                     .scheduleYear(command.scheduleYear())
                     .scheduleMonth(command.scheduleMonth())
                     .maxConcurrent(command.maxConcurrent())
-                    .applyStartTime(applyStartTime)
-                    .applyEndTime(applyEndTime)
+                    .applyStartTime(command.applyStartTime())
+                    .applyEndTime(command.applyEndTime())
                     .createdBy(command.userId())
                     .updatedBy(command.userId())
                     .build();
@@ -104,25 +98,4 @@ public class MonthlyScheduleConfigService {
         }
     }
 
-    /**
-     * 신청 기간의 기본값 시작 시간 계산
-     * 규칙: 해당 월의 전달 23일 00:00 (자정)
-     * 예: 2025년 12월 제한 → 2025년 11월 23일 00:00
-     */
-    private LocalDateTime getDefaultApplyStartTime(Integer scheduleYear, Integer scheduleMonth) {
-        YearMonth targetMonth = YearMonth.of(scheduleYear, scheduleMonth);
-        YearMonth previousMonth = targetMonth.minusMonths(1);
-        return previousMonth.atDay(23).atStartOfDay();
-    }
-
-    /**
-     * 신청 기간의 기본값 종료 시간 계산
-     * 규칙: 해당 월의 전달 27일 00:00 (자정)
-     * 예: 2025년 12월 제한 → 2025년 11월 27일 00:00
-     */
-    private LocalDateTime getDefaultApplyEndTime(Integer scheduleYear, Integer scheduleMonth) {
-        YearMonth targetMonth = YearMonth.of(scheduleYear, scheduleMonth);
-        YearMonth previousMonth = targetMonth.minusMonths(1);
-        return previousMonth.atDay(27).atStartOfDay();
-    }
 }

--- a/src/main/java/com/better/CommuteMate/schedule/application/dtos/MonthlyScheduleLimitCommand.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/dtos/MonthlyScheduleLimitCommand.java
@@ -1,19 +1,53 @@
 package com.better.CommuteMate.schedule.application.dtos;
 
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+
 public record MonthlyScheduleLimitCommand(
         Integer scheduleYear,
         Integer scheduleMonth,
         Integer maxConcurrent,
+        LocalDateTime applyStartTime,
+        LocalDateTime applyEndTime,
         Integer userId) {
+
     public static MonthlyScheduleLimitCommand from(
             Integer scheduleYear,
             Integer scheduleMonth,
             Integer maxConcurrent,
             Integer userId) {
+        // 기본 신청 기간 설정: 해당 월의 전달 23일 00:00 ~ 27일 00:00
+        LocalDateTime applyStartTime = getDefaultApplyStartTime(scheduleYear, scheduleMonth);
+        LocalDateTime applyEndTime = getDefaultApplyEndTime(scheduleYear, scheduleMonth);
+
         return new MonthlyScheduleLimitCommand(
                 scheduleYear,
-                scheduleMonth, 
+                scheduleMonth,
                 maxConcurrent,
+                applyStartTime,
+                applyEndTime,
                 userId);
+    }
+
+    /**
+     * 신청 기간의 기본값 시작 시간 계산
+     * 규칙: 해당 월의 전달 23일 00:00 (자정)
+     * 예: 2025년 12월 제한 → 2025년 11월 23일 00:00
+     */
+    private static LocalDateTime getDefaultApplyStartTime(Integer scheduleYear, Integer scheduleMonth) {
+        YearMonth targetMonth = YearMonth.of(scheduleYear, scheduleMonth);
+        YearMonth previousMonth = targetMonth.minusMonths(1);
+        return previousMonth.atDay(23).atStartOfDay();
+    }
+
+    /**
+     * 신청 기간의 기본값 종료 시간 계산
+     * 규칙: 해당 월의 전달 27일 00:00 (자정)
+     * 예: 2025년 12월 제한 → 2025년 11월 27일 00:00
+     */
+    private static LocalDateTime getDefaultApplyEndTime(Integer scheduleYear, Integer scheduleMonth) {
+        YearMonth targetMonth = YearMonth.of(scheduleYear, scheduleMonth);
+        YearMonth previousMonth = targetMonth.minusMonths(1);
+        return previousMonth.atDay(27).atStartOfDay();
     }
 }


### PR DESCRIPTION
## 📋 요약

근무 일정의 신청 기간을 설정하는 엔드포인트를 구현하고, 월별 제한 설정 시 기본 신청 기간을 자동으로 설정하는 기능을 추가했습니다.

## 🎯 주요 기능

### 1️⃣ 신청 기간 설정 엔드포인트
- **경로**: `POST /api/v1/admin/schedule/set-apply-term`
- **기능**: `applyStartTime`과 `applyEndTime` 업데이트
- **검증**: 시작 시간 < 종료 시간 필수

### 2️⃣ 기본 신청 기간 자동 설정
- **규칙**: 해당 월의 전달 23일 00:00 ~ 27일 00:00
- **예시**: 
  - 2025년 12월 설정 → 2025년 11월 23일 00:00 ~ 27일 00:00
  - 2025년 1월 설정 → 2024년 12월 23일 00:00 ~ 27일 00:00
- **위치**: `MonthlyScheduleLimitCommand.from()` 팩토리 메서드에서 자동 계산

## 📦 구현 상세

### 신규 컴포넌트
| 파일 | 설명 |
|------|------|
| `SetApplyTermRequest.java` | 신청 기간 설정 요청 DTO |
| `ApplyTermResponse.java` | 신청 기간 응답 DTO |
| `SetApplyTermCommand.java` | 신청 기간 설정 커맨드 |
| `ScheduleConfigException.java` | 스케줄 설정 예외 |
| `ApplyTermValidationResponseDetail.java` | 검증 오류 상세 정보 |

### 수정 컴포넌트
| 파일 | 변경사항 |
|------|---------|
| `MonthlyScheduleLimitCommand.java` | `applyStartTime`, `applyEndTime` 필드 추가 & 기본값 계산 로직 |
| `MonthlyScheduleConfigService.java` | Command 필드 사용, 불필요한 헬퍼 메서드 제거 |
| `MonthlyScheduleConfig.java` | `applyStartTime`, `applyEndTime`: `nullable = false` 유지 |
| `AdminScheduleController.java` | `setApplyTerm()` 엔드포인트 추가 |
| `ScheduleErrorCode.java` | 새 에러 코드 추가 |
| `AdminScheduleControllerTest.java` | 테스트 코드 수정 및 추가 |

## 🏗️ 설계 패턴

### Command 패턴 활용
```
Request DTO → Command (기본값 계산) → Service (비즈니스 로직) → Entity (DB 저장)
```

**Command 계층의 책임:**
- HTTP 요청 데이터 변환
- 기본값 계산 (기본 신청 기간: 전달 23일~27일)
- 불변 데이터 구조 (record)

**Service 계층의 책임:**
- 신규/업데이트 분기 처리
- Command → Entity 변환
- 비즈니스 로직 실행

## 📊 테스트 결과

✅ **모든 8개 테스트 통과**

```
✅ setMonthlyLimit_NewLimit_Success
✅ setMonthlyLimit_UpdateExisting_Success
✅ getMonthlyLimit_DataExists_Returns200
✅ getMonthlyLimit_DataNotExists_Returns404
✅ getAllMonthlyLimits_Success
✅ getAllMonthlyLimits_EmptyList
✅ setApplyTerm_NewConfig_Success
✅ setApplyTerm_UpdateExisting_Success
```

## 📝 API 명세

### 월별 제한 설정 (기본 신청 기간 자동 설정)
```
POST /api/v1/admin/schedule/monthly-limit
Content-Type: application/json

Request:
{
  "scheduleYear": 2025,
  "scheduleMonth": 12,
  "maxConcurrent": 10
}

Response (Success):
{
  "isSuccess": true,
  "message": "월별 스케줄 제한이 설정되었습니다.",
  "details": {
    "scheduleYear": 2025,
    "scheduleMonth": 12,
    "maxConcurrent": 10,
    "applyStartTime": "2025-11-23T00:00:00",  // ← 자동 설정됨
    "applyEndTime": "2025-11-27T00:00:00"     // ← 자동 설정됨
  }
}
```

### 신청 기간 설정 (커스터마이징)
```
POST /api/v1/admin/schedule/set-apply-term
Content-Type: application/json

Request:
{
  "scheduleYear": 2025,
  "scheduleMonth": 12,
  "applyStartTime": "2025-11-20T09:00:00",
  "applyEndTime": "2025-11-30T18:00:00"
}

Response (Success):
{
  "isSuccess": true,
  "message": "신청 기간이 설정되었습니다.",
  "details": {
    "scheduleYear": 2025,
    "scheduleMonth": 12,
    "applyStartTime": "2025-11-20T09:00:00",
    "applyEndTime": "2025-11-30T18:00:00"
  }
}
```

## 🔄 Git 커밋 이력

1. **8c5279b**: feat: 신청 기간 설정 엔드포인트 구현 및 테스트 코드 수정
2. **4b676dd**: fix: MonthlyScheduleConfig 생성 시 기본 신청 기간 자동 설정
3. **40b1135**: refactor: MonthlyScheduleLimitCommand에 기본 신청 기간 설정 로직 이관

## ✨ 주의사항

- 모든 신규 레코드는 기본 신청 기간(전달 23일~27일)이 자동으로 설정됨
- `setApplyTerm()`으로 언제든 신청 기간 수정 가능
- 신청 기간 검증: `startTime < endTime` 필수
- 1월 설정 시 전달이 12월(전년)이 되는 경우도 정상 처리됨

---

준비 완료! 🚀