### PR TITLE
fix: 이메일 템플릿 인라인 스타일로 변경 (네이버메일 호환)

### DIFF
--- a/src/main/java/com/better/CommuteMate/auth/application/EmailService.java
+++ b/src/main/java/com/better/CommuteMate/auth/application/EmailService.java
@@ -46,7 +46,7 @@ public class EmailService {
     }
 
     /**
-     * 이메일 HTML 템플릿
+     * 이메일 HTML 템플릿 (인라인 스타일 - 네이버, 아웃룩 등 호환)
      */
     private String buildEmailContent(String code) {
         return """
@@ -54,47 +54,49 @@ public class EmailService {
                 <html>
                 <head>
                     <meta charset="UTF-8">
-                    <style>
-                        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
-                        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
-                        .header { background-color: #4CAF50; color: white; padding: 20px; text-align: center; }
-                        .content { background-color: #f9f9f9; padding: 30px; text-align: center; }
-                        .code-box {
-                            display: inline-block;
-                            padding: 20px 40px;
-                            background-color: #ffffff;
-                            border: 2px dashed #4CAF50;
-                            border-radius: 10px;
-                            margin: 20px 0;
-                            font-size: 32px;
-                            font-weight: bold;
-                            letter-spacing: 8px;
-                            color: #4CAF50;
-                        }
-                        .footer { text-align: center; padding: 20px; color: #777; font-size: 12px; }
-                    </style>
                 </head>
-                <body>
-                    <div class="container">
-                        <div class="header">
-                            <h1>CommuteMate 이메일 인증</h1>
-                        </div>
-                        <div class="content">
-                            <h2>이메일 인증번호</h2>
-                            <p>아래 인증번호를 입력하여 이메일 인증을 완료해주세요.</p>
-                            <div class="code-box">%s</div>
-                            <p style="color: #ff0000; font-size: 14px;">
-                                ⚠️ 이 인증번호는 <strong>5분</strong> 동안만 유효합니다.
-                            </p>
-                            <p style="color: #777; font-size: 14px;">
-                                본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.
-                            </p>
-                        </div>
-                        <div class="footer">
-                            <p>본 메일은 발신 전용입니다. 문의사항은 고객센터를 이용해주세요.</p>
-                            <p>&copy; 2025 CommuteMate. All rights reserved.</p>
-                        </div>
-                    </div>
+                <body style="margin: 0; padding: 0; font-family: Arial, sans-serif; line-height: 1.6; color: #333333;">
+                    <table role="presentation" width="100%%" cellspacing="0" cellpadding="0" border="0">
+                        <tr>
+                            <td align="center" style="padding: 20px;">
+                                <table role="presentation" width="600" cellspacing="0" cellpadding="0" border="0" style="max-width: 600px; width: 100%%;">
+                                    <!-- Header -->
+                                    <tr>
+                                        <td align="center" style="background-color: #4CAF50; color: #ffffff; padding: 20px;">
+                                            <h1 style="margin: 0; font-size: 24px;">CommuteMate 이메일 인증</h1>
+                                        </td>
+                                    </tr>
+                                    <!-- Content -->
+                                    <tr>
+                                        <td align="center" style="background-color: #f9f9f9; padding: 30px;">
+                                            <h2 style="margin: 0 0 10px 0; color: #333333;">이메일 인증번호</h2>
+                                            <p style="margin: 0 0 20px 0; color: #333333;">아래 인증번호를 입력하여 이메일 인증을 완료해주세요.</p>
+                                            <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                                                <tr>
+                                                    <td align="center" style="padding: 20px 40px; background-color: #ffffff; border: 2px dashed #4CAF50; border-radius: 10px;">
+                                                        <span style="font-size: 32px; font-weight: bold; letter-spacing: 8px; color: #4CAF50;">%s</span>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                            <p style="margin: 20px 0 0 0; color: #ff0000; font-size: 14px;">
+                                                ⚠️ 이 인증번호는 <strong>5분</strong> 동안만 유효합니다.
+                                            </p>
+                                            <p style="margin: 10px 0 0 0; color: #777777; font-size: 14px;">
+                                                본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.
+                                            </p>
+                                        </td>
+                                    </tr>
+                                    <!-- Footer -->
+                                    <tr>
+                                        <td align="center" style="padding: 20px; color: #777777; font-size: 12px;">
+                                            <p style="margin: 0;">본 메일은 발신 전용입니다. 문의사항은 고객센터를 이용해주세요.</p>
+                                            <p style="margin: 5px 0 0 0;">&copy; 2025 CommuteMate. All rights reserved.</p>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
                 </body>
                 </html>
                 """.formatted(code);


### PR DESCRIPTION
## 1. 요약 📝
이메일 인증 템플릿이 네이버메일에서 깨지는 문제 수정

## 2. 관련 이슈 🔗
관련 이슈 없음

## 3. 주요 변경 사항 🔑

- **핵심 로직**
  - EmailService: `<style>` 태그 제거하고 모든 스타일을 인라인으로 변경
  - 테이블 기반 레이아웃으로 변경하여 이메일 클라이언트 호환성 개선
  - Gmail, 네이버메일, 아웃룩 등 모든 클라이언트에서 동일하게 표시

## 4. 중점 리뷰 요청 사항 💡
- 이메일 템플릿 디자인이 기존과 동일하게 유지되는지 확인 부탁

## 5. 스크린샷 또는 테스트 결과 📸
N/A