### PR TITLE
feat: 로그인/토큰 갱신 응답에 유저 정보 추가

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -109,12 +109,16 @@ Base Path: `/api/v1/auth`
   "isSuccess": true,
   "message": "로그인 성공",
   "details": {
-    "accessToken": "eyJhbGciOiJIUzI1Ni...",
-    "refreshToken": "eyJhbGciOiJIUzI1Ni...",
+    "accessToken": "JWT 토큰",
+    "refreshToken": "리프레시 토큰",
     "tokenType": "Bearer",
-    "expiresAt": 1736560000
+    "expiresAt": 1234567890000,
+    "userId": 1,
+    "userName": "홍길동",
+    "email": "user@example.com",
+    "roleCode": "RL01"
   }
-}
+} 
 ```
 
 ### 1.5 Logout
@@ -145,7 +149,11 @@ Base Path: `/api/v1/auth`
     "accessToken": "eyJhbGciOiJIUzI1Ni...",
     "refreshToken": "eyJhbGciOiJIUzI1Ni...",
     "tokenType": "Bearer",
-    "expiresAt": 1736560000
+    "expiresAt": 1736560000,
+    "userId": 1,
+    "userName": "홍길동",
+    "email": "user@example.com",
+    "roleCode": "RL01"
   }
 }
 ```

--- a/src/main/java/com/better/CommuteMate/auth/application/AuthService.java
+++ b/src/main/java/com/better/CommuteMate/auth/application/AuthService.java
@@ -145,7 +145,8 @@ public class AuthService {
         user.setRefreshToken(refreshToken);
         userRepository.save(user);
         long expiresAt = jwtTokenProvider.getExpiration(accessToken);
-        return new AuthTokens(accessToken, refreshToken, expiresAt);
+        return new AuthTokens(accessToken, refreshToken, expiresAt,
+                user.getUserId(), user.getName(), user.getEmail(), user.getRoleCode());
     }
 
     public void logout(String token) {
@@ -178,6 +179,7 @@ public class AuthService {
         user.setRefreshToken(newRefreshToken);
         userRepository.save(user);
         long expiresAt = jwtTokenProvider.getExpiration(newAccessToken);
-        return new AuthTokens(newAccessToken, newRefreshToken, expiresAt);
+        return new AuthTokens(newAccessToken, newRefreshToken, expiresAt,
+                user.getUserId(), user.getName(), user.getEmail(), user.getRoleCode());
     }
 }

--- a/src/main/java/com/better/CommuteMate/auth/application/dto/AuthTokens.java
+++ b/src/main/java/com/better/CommuteMate/auth/application/dto/AuthTokens.java
@@ -1,14 +1,25 @@
 package com.better.CommuteMate.auth.application.dto;
 
+import com.better.CommuteMate.global.code.CodeType;
+
 public class AuthTokens {
     private final String accessToken;
     private final String refreshToken;
     private final long expiresAt;
+    private final Integer userId;
+    private final String userName;
+    private final String email;
+    private final CodeType roleCode;
 
-    public AuthTokens(String accessToken, String refreshToken, long expiresAt) {
+    public AuthTokens(String accessToken, String refreshToken, long expiresAt,
+                      Integer userId, String userName, String email, CodeType roleCode) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
         this.expiresAt = expiresAt;
+        this.userId = userId;
+        this.userName = userName;
+        this.email = email;
+        this.roleCode = roleCode;
     }
 
     public String getAccessToken() {
@@ -21,5 +32,21 @@ public class AuthTokens {
 
     public long getExpiresAt() {
         return expiresAt;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public CodeType getRoleCode() {
+        return roleCode;
     }
 }

--- a/src/main/java/com/better/CommuteMate/auth/controller/AuthController.java
+++ b/src/main/java/com/better/CommuteMate/auth/controller/AuthController.java
@@ -70,6 +70,10 @@ public class AuthController {
                 .refreshToken(tokens.getRefreshToken())
                 .tokenType("Bearer")
                 .expiresAt(tokens.getExpiresAt())
+                .userId(tokens.getUserId())
+                .userName(tokens.getUserName())
+                .email(tokens.getEmail())
+                .roleCode(tokens.getRoleCode().getFullCode())
                 .build();
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
@@ -109,6 +113,10 @@ public class AuthController {
                 .refreshToken(tokens.getRefreshToken())
                 .tokenType("Bearer")
                 .expiresAt(tokens.getExpiresAt())
+                .userId(tokens.getUserId())
+                .userName(tokens.getUserName())
+                .email(tokens.getEmail())
+                .roleCode(tokens.getRoleCode().getFullCode())
                 .build();
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/src/main/java/com/better/CommuteMate/auth/controller/dto/LoginResponse.java
+++ b/src/main/java/com/better/CommuteMate/auth/controller/dto/LoginResponse.java
@@ -14,4 +14,8 @@ public class LoginResponse extends ResponseDetail {
     private final String refreshToken;
     private final String tokenType;
     private final Long expiresAt;
+    private final Integer userId;
+    private final String userName;
+    private final String email;
+    private final String roleCode;
 }


### PR DESCRIPTION
## 1. 요약 📝
로그인 및 토큰 갱신 API 응답에 유저 정보(userId, userName, email, roleCode)를 포함하도록 개선

## 2. 관련 이슈 🔗
관련 이슈 없음

## 3. 주요 변경 사항 🔑

- **핵심 로직**
  - AuthTokens DTO: 유저 정보 필드(userId, userName, email, roleCode) 추가
  - AuthService: login/refresh 시 유저 정보를 AuthTokens에 포함
  - AuthController: LoginResponse 빌드 시 유저 정보 매핑
  - LoginResponse: 유저 정보 필드 추가

- **문서**
  - docs/api.md: 로그인/토큰 갱신 API 응답 스펙 업데이트

## 4. 중점 리뷰 요청 사항 💡
- LoginResponse에 포함된 유저 정보 필드가 적절한지 확인 부탁

## 5. 스크린샷 또는 테스트 결과 📸
N/A