### PR TITLE
feat: 업무 완료 기록 API 추가 및 업무 생성 API 수정

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -819,29 +819,33 @@ Base Path: `/api/v1/tasks`
   "details": {
     "taskId": 50,
     "title": "서버 점검",
-    "assigneeId": 101,
+    "assigneeId": null,
+    "assigneeName": null,
     "taskDate": "2025-10-24",
     "taskTime": "14:00:00",
     "taskType": "TT01",
-    "isCompleted": false
+    "taskTypeName": "정기 업무",
+    "isCompleted": false,
+    "completedByName": null,
+    "completedTime": null
   }
 }
 ```
 
-### 6.3 Create Task (Admin)
-업무 생성 (관리자 전용).
+### 6.3 Create Task
+업무를 생성합니다.
 - **POST** `/api/v1/tasks`
 
 **Request Body**
 ```json
 {
   "title": "서버 점검",
-  "assigneeId": 101,
   "taskDate": "2025-10-24",
   "taskTime": "14:00:00",
   "taskType": "TT01"
 }
 ```
+> `taskType`: `TT01`(정기 업무), `TT02`(비정기 업무). 미입력 시 `TT01` 기본값.
 
 **Response (201 Created)**
 ```json
@@ -851,11 +855,15 @@ Base Path: `/api/v1/tasks`
   "details": {
     "taskId": 51,
     "title": "서버 점검",
-    "assigneeId": 101,
+    "assigneeId": null,
+    "assigneeName": null,
     "taskDate": "2025-10-24",
     "taskTime": "14:00:00",
     "taskType": "TT01",
-    "isCompleted": false
+    "taskTypeName": "정기 업무",
+    "isCompleted": false,
+    "completedByName": null,
+    "completedTime": null
   }
 }
 ```
@@ -898,8 +906,8 @@ Base Path: `/api/v1/tasks`
 }
 ```
 
-### 6.6 Set Complete (Admin)
-업무 완료 상태 설정 (관리자 전용).
+### 6.6 Set Complete
+업무 완료 상태를 설정합니다.
 - **PATCH** `/api/v1/tasks/{taskId}/complete`
 
 **Request Body**
@@ -921,7 +929,40 @@ Base Path: `/api/v1/tasks`
 }
 ```
 
-### 6.7 Delete Task (Admin)
+### 6.7 Complete Record
+업무의 실제 수행자와 수행 시간을 기록합니다. 기록 시 자동으로 완료 처리됩니다.
+- **PATCH** `/api/v1/tasks/{taskId}/complete-record`
+
+**Request Body**
+```json
+{
+  "completedByName": "홍길동",
+  "completedTime": "09:30:00"
+}
+```
+
+**Response (200 OK)**
+```json
+{
+  "isSuccess": true,
+  "message": "업무 완료가 기록되었습니다.",
+  "details": {
+    "taskId": 50,
+    "title": "서버 점검",
+    "assigneeId": null,
+    "assigneeName": null,
+    "taskDate": "2025-10-24",
+    "taskTime": "14:00:00",
+    "taskType": "TT01",
+    "taskTypeName": "정기 업무",
+    "isCompleted": true,
+    "completedByName": "홍길동",
+    "completedTime": "09:30:00"
+  }
+}
+```
+
+### 6.8 Delete Task (Admin)
 업무 삭제 (관리자 전용).
 - **DELETE** `/api/v1/tasks/{taskId}`
 
@@ -934,7 +975,7 @@ Base Path: `/api/v1/tasks`
 }
 ```
 
-### 6.8 Batch Update Tasks (Admin)
+### 6.9 Batch Update Tasks (Admin)
 업무 일괄 생성/수정 (관리자 전용).
 - **PUT** `/api/v1/tasks/batch`
 
@@ -977,10 +1018,10 @@ Base Path: `/api/v1/tasks`
 }
 ```
 
-### 6.9 Task Template API (`task/task-templates`)
+### 6.10 Task Template API (`task/task-templates`)
 Base Path: `/api/v1/task-templates`
 
-#### 6.9.1 Get Templates
+#### 6.10.1 Get Templates
 템플릿 목록 조회.
 - **GET** `/api/v1/task-templates?activeOnly=false`
 
@@ -1002,7 +1043,7 @@ Base Path: `/api/v1/task-templates`
 }
 ```
 
-#### 6.9.2 Get Template Detail
+#### 6.10.2 Get Template Detail
 템플릿 상세 조회.
 - **GET** `/api/v1/task-templates/{templateId}`
 
@@ -1024,7 +1065,7 @@ Base Path: `/api/v1/task-templates`
 }
 ```
 
-#### 6.9.3 Create Template (Admin)
+#### 6.10.3 Create Template (Admin)
 템플릿 생성 (관리자 전용).
 - **POST** `/api/v1/task-templates`
 
@@ -1054,7 +1095,7 @@ Base Path: `/api/v1/task-templates`
 }
 ```
 
-#### 6.9.4 Update Template (Admin)
+#### 6.10.4 Update Template (Admin)
 템플릿 수정 (관리자 전용).
 - **PUT** `/api/v1/task-templates/{templateId}`
 
@@ -1067,7 +1108,7 @@ Base Path: `/api/v1/task-templates`
 }
 ```
 
-#### 6.9.5 Delete Template (Admin)
+#### 6.10.5 Delete Template (Admin)
 템플릿 삭제 (관리자 전용).
 - **DELETE** `/api/v1/task-templates/{templateId}`
 
@@ -1080,7 +1121,7 @@ Base Path: `/api/v1/task-templates`
 }
 ```
 
-#### 6.9.6 Set Template Active (Admin)
+#### 6.10.6 Set Template Active (Admin)
 템플릿 활성화/비활성화 (관리자 전용).
 - **PATCH** `/api/v1/task-templates/{templateId}/active?isActive=true`
 
@@ -1093,7 +1134,7 @@ Base Path: `/api/v1/task-templates`
 }
 ```
 
-#### 6.9.7 Apply Template (Admin)
+#### 6.10.7 Apply Template (Admin)
 템플릿 적용하여 업무 생성 (관리자 전용).
 - **POST** `/api/v1/task-templates/{templateId}/apply`
 

--- a/src/main/java/com/better/CommuteMate/domain/task/entity/Task.java
+++ b/src/main/java/com/better/CommuteMate/domain/task/entity/Task.java
@@ -29,7 +29,7 @@ public class Task {
     private String title;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "assignee_id", nullable = false)
+    @JoinColumn(name = "assignee_id")
     private User assignee;
 
     @Column(name = "task_date", nullable = false)
@@ -45,6 +45,12 @@ public class Task {
     @Column(name = "is_completed", nullable = false)
     @Builder.Default
     private Boolean isCompleted = false;
+
+    @Column(name = "completed_by_name", length = 50)
+    private String completedByName;
+
+    @Column(name = "completed_time")
+    private LocalTime completedTime;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -95,12 +101,33 @@ public class Task {
         this.updatedBy = updatedBy;
     }
 
-    // 팩토리 메서드
+    // 업무 완료 기록 (실제 수행자, 수행 시간)
+    public void completeRecord(String completedByName, LocalTime completedTime, Integer updatedBy) {
+        this.completedByName = completedByName;
+        this.completedTime = completedTime;
+        this.isCompleted = true;
+        this.updatedBy = updatedBy;
+    }
+
+    // 팩토리 메서드 (담당자 지정)
     public static Task create(String title, User assignee, LocalDate taskDate,
             LocalTime taskTime, CodeType taskType, Integer createdBy) {
         return Task.builder()
                 .title(title)
                 .assignee(assignee)
+                .taskDate(taskDate)
+                .taskTime(taskTime)
+                .taskType(taskType)
+                .isCompleted(false)
+                .createdBy(createdBy)
+                .build();
+    }
+
+    // 팩토리 메서드 (담당자 미지정)
+    public static Task create(String title, LocalDate taskDate,
+            LocalTime taskTime, CodeType taskType, Integer createdBy) {
+        return Task.builder()
+                .title(title)
                 .taskDate(taskDate)
                 .taskTime(taskTime)
                 .taskType(taskType)

--- a/src/main/java/com/better/CommuteMate/task/application/TaskService.java
+++ b/src/main/java/com/better/CommuteMate/task/application/TaskService.java
@@ -80,16 +80,14 @@ public class TaskService {
     }
 
     /**
-     * 업무 생성
+     * 업무 생성 (담당자 미지정)
      */
     @Transactional
     public TaskResponse createTask(CreateTaskRequest request, Integer currentUserId) {
-        User assignee = findUserById(request.getAssigneeId());
         CodeType taskType = validateAndGetTaskType(request.getTaskType());
 
         Task task = Task.create(
                 request.getTitle(),
-                assignee,
                 request.getTaskDate(),
                 request.getTaskTime(),
                 taskType,
@@ -132,6 +130,16 @@ public class TaskService {
     public TaskResponse setComplete(Long taskId, Boolean isCompleted, Integer currentUserId) {
         Task task = findTaskById(taskId);
         task.setCompleted(isCompleted, currentUserId);
+        return TaskResponse.from(task);
+    }
+
+    /**
+     * 업무 완료 기록 (실제 수행자, 수행 시간)
+     */
+    @Transactional
+    public TaskResponse completeRecord(Long taskId, CompleteRecordRequest request, Integer currentUserId) {
+        Task task = findTaskById(taskId);
+        task.completeRecord(request.getCompletedByName(), request.getCompletedTime(), currentUserId);
         return TaskResponse.from(task);
     }
 

--- a/src/main/java/com/better/CommuteMate/task/controller/TaskController.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/TaskController.java
@@ -120,6 +120,22 @@ public class TaskController {
         return ResponseEntity.ok(new Response(true, message, response));
     }
 
+    @Operation(summary = "업무 완료 기록", description = "업무의 실제 수행자와 수행 시간을 기록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "기록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "404", description = "업무를 찾을 수 없음")
+    })
+    @PatchMapping("/{taskId}/complete-record")
+    public ResponseEntity<Response> completeRecord(
+            @PathVariable Long taskId,
+            @Valid @RequestBody CompleteRecordRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Integer currentUserId = userDetails.getUser().getUserId();
+        TaskResponse response = taskService.completeRecord(taskId, request, currentUserId);
+        return ResponseEntity.ok(new Response(true, "업무 완료가 기록되었습니다.", response));
+    }
+
     @Operation(summary = "업무 삭제", description = "업무를 삭제합니다. (관리자 전용)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "삭제 성공"),

--- a/src/main/java/com/better/CommuteMate/task/controller/dtos/CompleteRecordRequest.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/dtos/CompleteRecordRequest.java
@@ -1,0 +1,25 @@
+package com.better.CommuteMate.task.controller.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompleteRecordRequest {
+
+    @NotBlank(message = "수행자 이름은 필수입니다.")
+    @Size(max = 50, message = "수행자 이름은 50자 이내로 입력해주세요.")
+    private String completedByName;
+
+    @NotNull(message = "수행 시간은 필수입니다.")
+    private LocalTime completedTime;
+}

--- a/src/main/java/com/better/CommuteMate/task/controller/dtos/CreateTaskRequest.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/dtos/CreateTaskRequest.java
@@ -21,9 +21,6 @@ public class CreateTaskRequest {
     @Size(max = 200, message = "업무명은 200자 이내로 입력해주세요.")
     private String title;
 
-    @NotNull(message = "담당자 ID는 필수입니다.")
-    private Integer assigneeId;
-
     @NotNull(message = "업무 날짜는 필수입니다.")
     private LocalDate taskDate;
 

--- a/src/main/java/com/better/CommuteMate/task/controller/dtos/TaskResponse.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/dtos/TaskResponse.java
@@ -25,18 +25,22 @@ public class TaskResponse extends ResponseDetail {
     private String taskType; // TT01 or TT02
     private String taskTypeName; // 정기 업무 or 비정기 업무
     private Boolean isCompleted;
+    private String completedByName;
+    private LocalTime completedTime;
 
     public static TaskResponse from(Task task) {
         return TaskResponse.builder()
                 .taskId(task.getTaskId())
                 .title(task.getTitle())
-                .assigneeId(task.getAssignee().getUserId())
-                .assigneeName(task.getAssignee().getName())
+                .assigneeId(task.getAssignee() != null ? task.getAssignee().getUserId() : null)
+                .assigneeName(task.getAssignee() != null ? task.getAssignee().getName() : null)
                 .taskDate(task.getTaskDate())
                 .taskTime(task.getTaskTime())
                 .taskType(task.getTaskType().getFullCode())
                 .taskTypeName(task.getTaskType().getCodeValue())
                 .isCompleted(task.getIsCompleted())
+                .completedByName(task.getCompletedByName())
+                .completedTime(task.getCompletedTime())
                 .build();
     }
 }


### PR DESCRIPTION
## 1. 요약 📝
업무 생성 API에서 담당자 지정을 제거하고, 실제 업무 수행자와 수행 시간을 기록할 수 있는 새 API를 추가

## 2. 관련 이슈 🔗
관련 이슈 없음

## 3. 주요 변경 사항 🔑

- **API 변경 사항**
  - [POST] /api/v1/tasks: `assigneeId` 필드 제거 (담당자 미지정으로 업무 생성)
  - [PATCH] /api/v1/tasks/{taskId}/complete-record: 신규 API 추가

- **데이터베이스 변경 사항**
  - Task 테이블에 `completed_by_name` (VARCHAR 50) 컬럼 추가
  - Task 테이블에 `completed_time` (TIME) 컬럼 추가
  - Task 테이블의 `assignee_id` 컬럼 nullable로 변경

- **핵심 로직**
  - Task 엔티티: `completedByName`, `completedTime` 필드 추가, `assignee` nullable 변경
  - TaskService: `completeRecord()` 메서드 추가, `createTask()` 수정
  - TaskController: `complete-record` 엔드포인트 추가
  - CreateTaskRequest: `assigneeId` 필드 제거
  - TaskResponse: `completedByName`, `completedTime` 필드 추가

- **문서**
  - docs/api.md: Task API 섹션 업데이트

## 4. 중점 리뷰 요청 사항 💡
- 업무 완료 기록 시 자동으로 `isCompleted = true`로 설정되는 로직이 적절한지 확인 부탁

## 5. 스크린샷 또는 테스트 결과 📸
N/A