### PR TITLE
[FEAT] FAQ 작성 시 카테고리 최대 3개 지정 가능하도록 기능 확장

### DIFF
--- a/src/main/java/com/better/CommuteMate/category/application/CategoryService.java
+++ b/src/main/java/com/better/CommuteMate/category/application/CategoryService.java
@@ -9,7 +9,7 @@ import com.better.CommuteMate.category.application.dto.response.PutCategoryUpdat
 import com.better.CommuteMate.domain.category.entity.Category;
 import com.better.CommuteMate.domain.category.repository.CategoryRepository;
 import com.better.CommuteMate.domain.category.repository.ManagerCategoryRepository;
-import com.better.CommuteMate.domain.faq.repository.FaqRepository;
+import com.better.CommuteMate.domain.faq.repository.FaqCategoryRepository;
 import com.better.CommuteMate.global.exceptions.CustomException;
 import com.better.CommuteMate.global.exceptions.error.CategoryErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ import java.util.List;
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
-    private final FaqRepository faqRepository;
+    private final FaqCategoryRepository faqCategoryRepository;
     private final ManagerCategoryRepository managerCategoryRepository;
 
     public PostCategoryResponse registerCategory(PostCategoryRequest request) {
@@ -67,7 +67,7 @@ public class CategoryService {
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CustomException(CategoryErrorCode.CATEGORY_NOT_FOUND));
 
-        if (faqRepository.existsByCategoryId(categoryId)|| managerCategoryRepository.existsByCategoryId(categoryId)) {
+        if (faqCategoryRepository.existsByCategory_Id(categoryId)|| managerCategoryRepository.existsByCategoryId(categoryId)) {
             throw new CustomException(CategoryErrorCode.CATEGORY_DELETE_NOT_ALLOWED);
         }
 

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -55,6 +55,15 @@ public class Faq {
     @Column(name = "deleted_at")
     private LocalDate deletedAt;
 
+//    public void addCategory(Category category) {
+//        if (this.faqCategories.size() >= 3) {
+//            throw new IllegalArgumentException("카테고리는 최대 3개까지 가능합니다.");
+//        }
+//
+//        FaqCategory fc = new FaqCategory(this, category);
+//        this.faqCategories.add(fc);
+//    }
+
     @PrePersist
     protected void onCreate() {
         this.updatedDate = LocalDate.now();

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -7,6 +7,8 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "faq")
@@ -40,6 +42,9 @@ public class Faq {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
+
+    @OneToMany(mappedBy = "faq", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FaqCategory> faqCategories = new ArrayList<>();
 
     @Column(name = "updated_date", nullable = false)
     private LocalDate updatedDate;

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -39,10 +39,6 @@ public class Faq {
     @JoinColumn(name = "writer_id", nullable = false)
     private User writer;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = false)
-    private Category category;
-
     @OneToMany(mappedBy = "faq", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FaqCategory> faqCategories = new ArrayList<>();
 
@@ -55,14 +51,14 @@ public class Faq {
     @Column(name = "deleted_at")
     private LocalDate deletedAt;
 
-//    public void addCategory(Category category) {
-//        if (this.faqCategories.size() >= 3) {
-//            throw new IllegalArgumentException("카테고리는 최대 3개까지 가능합니다.");
-//        }
-//
-//        FaqCategory fc = new FaqCategory(this, category);
-//        this.faqCategories.add(fc);
-//    }
+    public void addCategory(Category category) {
+        if (this.faqCategories.size() >= 3) {
+            throw new IllegalArgumentException("카테고리는 최대 3개까지 가능합니다.");
+        }
+
+        FaqCategory fc = new FaqCategory(this, category);
+        this.faqCategories.add(fc);
+    }
 
     @PrePersist
     protected void onCreate() {
@@ -81,7 +77,7 @@ public class Faq {
             String content,
             String answer,
             String etc,
-            Category category,
+            List<Category> categories,
             User writer
     ) {
         Faq faq = new Faq();
@@ -90,8 +86,12 @@ public class Faq {
         faq.content = content;
         faq.answer = answer;
         faq.etc = etc;
-        faq.category = category;
         faq.writer = writer;
+
+        for (Category category : categories) {
+            faq.addCategory(category);
+        }
+
         return faq;
     }
 
@@ -101,7 +101,7 @@ public class Faq {
             String content,
             String answer,
             String etc,
-            Category category,
+            List<Category> categories,
             User writer
     ) {
         this.title = title;
@@ -109,8 +109,13 @@ public class Faq {
         this.content = content;
         this.answer = answer;
         this.etc = etc;
-        this.category = category;
         this.writer = writer;
+
+        this.faqCategories.clear();
+
+        for (Category category : categories) {
+            this.addCategory(category);
+        }
     }
 
     public void delete() {

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -2,6 +2,8 @@ package com.better.CommuteMate.domain.faq.entity;
 
 import com.better.CommuteMate.domain.category.entity.Category;
 import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.FaqErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -53,7 +55,7 @@ public class Faq {
 
     public void addCategory(Category category) {
         if (this.faqCategories.size() >= 3) {
-            throw new IllegalArgumentException("카테고리는 최대 3개까지 가능합니다.");
+            throw CustomException.of(FaqErrorCode.CATEGORY_LIMIT_EXCEEDED);
         }
 
         FaqCategory fc = new FaqCategory(this, category);

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqCategory.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqCategory.java
@@ -1,0 +1,18 @@
+package com.better.CommuteMate.domain.faq.entity;
+
+import com.better.CommuteMate.domain.category.entity.Category;
+import jakarta.persistence.*;
+
+@Entity
+public class FaqCategory {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Faq faq;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
+}

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqCategory.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqCategory.java
@@ -2,17 +2,29 @@ package com.better.CommuteMate.domain.faq.entity;
 
 import com.better.CommuteMate.domain.category.entity.Category;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FaqCategory {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "faq_id", nullable = false)
     private Faq faq;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
     private Category category;
+
+    public FaqCategory(Faq faq, Category category) {
+        this.faq = faq;
+        this.category = category;
+    }
 }

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqHistory.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqHistory.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Table(name = "faq_history")
@@ -68,6 +69,7 @@ public class FaqHistory {
 
     public static FaqHistory create(Faq faq) {
         FaqHistory history = new FaqHistory();
+
         history.faq = faq;
         history.title = faq.getTitle();
         history.complainantName = faq.getComplainantName();
@@ -75,6 +77,7 @@ public class FaqHistory {
         history.answer = faq.getAnswer();
         history.etc = faq.getEtc();
         history.writerName = faq.getWriter().getName();
+
         history.managers = faq.getFaqCategories()
                 .stream()
                 .flatMap(fc -> fc.getCategory().getManagers().stream())
@@ -84,10 +87,12 @@ public class FaqHistory {
                         mc.getCategory().getName()
                 ))
                 .toList();
-        history.categoryNames = faq.getFaqCategories()
+
+        history.categoryName = faq.getFaqCategories()
                 .stream()
                 .map(fc -> fc.getCategory().getName())
-                .toList();
+                .collect(Collectors.joining(", ")); // ← 문자열로 변환
+
         return history;
     }
 

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqHistory.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqHistory.java
@@ -46,7 +46,15 @@ public class FaqHistory {
     private LocalDate editedAt;  // 수정된 날짜
 
     @Column(name = "category_name", length = 100, nullable = false)
-    private String categoryName;  // 분류명
+    private String categoryName;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "faq_history_categories",
+            joinColumns = @JoinColumn(name = "faq_history_id")
+    )
+    @Column(name = "category_name")
+    private List<String> categoryNames; // 분류명
 
     // FK: faq_id → faq(id)
     @ManyToOne(fetch = FetchType.LAZY)
@@ -67,15 +75,19 @@ public class FaqHistory {
         history.answer = faq.getAnswer();
         history.etc = faq.getEtc();
         history.writerName = faq.getWriter().getName();
-        history.managers = faq.getCategory().getManagers()
+        history.managers = faq.getFaqCategories()
                 .stream()
+                .flatMap(fc -> fc.getCategory().getManagers().stream())
                 .map(mc -> new ManagerSnapshot(
                         mc.getManager().getName(),
                         mc.getManager().getTeam().getName(),
                         mc.getCategory().getName()
                 ))
                 .toList();
-        history.categoryName = faq.getCategory().getName();
+        history.categoryNames = faq.getFaqCategories()
+                .stream()
+                .map(fc -> fc.getCategory().getName())
+                .toList();
         return history;
     }
 

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqHistory.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqHistory.java
@@ -46,9 +46,6 @@ public class FaqHistory {
     @Column(name = "edited_at", nullable = false)
     private LocalDate editedAt;  // 수정된 날짜
 
-    @Column(name = "category_name", length = 100, nullable = false)
-    private String categoryName;
-
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(
             name = "faq_history_categories",
@@ -88,10 +85,10 @@ public class FaqHistory {
                 ))
                 .toList();
 
-        history.categoryName = faq.getFaqCategories()
+        history.categoryNames = faq.getFaqCategories()
                 .stream()
                 .map(fc -> fc.getCategory().getName())
-                .collect(Collectors.joining(", ")); // ← 문자열로 변환
+                .toList();
 
         return history;
     }

--- a/src/main/java/com/better/CommuteMate/domain/faq/repository/FaqCategoryRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/repository/FaqCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.better.CommuteMate.domain.faq.repository;
+
+import com.better.CommuteMate.domain.faq.entity.FaqCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FaqCategoryRepository extends JpaRepository<FaqCategory, Long> {
+
+    boolean existsByCategory_Id(Long categoryId);
+
+}

--- a/src/main/java/com/better/CommuteMate/domain/faq/repository/FaqQueryRepositoryImpl.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/repository/FaqQueryRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.better.CommuteMate.domain.faq.repository;
 
+import com.better.CommuteMate.domain.category.entity.QCategory;
 import com.better.CommuteMate.domain.category.entity.QManagerCategory;
 import com.better.CommuteMate.domain.faq.entity.Faq;
 import com.better.CommuteMate.domain.faq.entity.QFaq;
+import com.better.CommuteMate.domain.faq.entity.QFaqCategory;
 import com.better.CommuteMate.domain.manager.entity.QManager;
 import com.better.CommuteMate.faq.application.dto.request.FaqSearchScope;
 import com.querydsl.core.BooleanBuilder;
@@ -22,15 +24,25 @@ public class FaqQueryRepositoryImpl implements FaqQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Faq> searchFaqs( Long teamId, Long categoryId, String keyword, FaqSearchScope searchScope, LocalDate startDate, LocalDate endDate, Pageable pageable) {
+    public Page<Faq> searchFaqs(
+            Long teamId,
+            Long categoryId,
+            String keyword,
+            FaqSearchScope searchScope,
+            LocalDate startDate,
+            LocalDate endDate,
+            Pageable pageable
+    ) {
         QFaq faq = QFaq.faq;
+        QFaqCategory fc = QFaqCategory.faqCategory;
+        QCategory category = QCategory.category;
         QManagerCategory mc = QManagerCategory.managerCategory;
         QManager manager = QManager.manager;
 
         BooleanBuilder where = new BooleanBuilder();
 
         if (categoryId != null) {
-            where.and(faq.category.id.eq(categoryId));
+            where.and(fc.category.id.eq(categoryId));
         }
 
         if (teamId != null) {
@@ -40,7 +52,7 @@ public class FaqQueryRepositoryImpl implements FaqQueryRepository {
                             .from(mc)
                             .join(mc.manager, manager)
                             .where(
-                                    mc.category.eq(faq.category),
+                                    mc.category.eq(fc.category),
                                     manager.team.id.eq(teamId)
                             )
                             .exists()
@@ -59,6 +71,7 @@ public class FaqQueryRepositoryImpl implements FaqQueryRepository {
             }
         }
 
+        // 날짜
         if (startDate != null) {
             where.and(faq.updatedDate.goe(startDate));
         }
@@ -68,17 +81,21 @@ public class FaqQueryRepositoryImpl implements FaqQueryRepository {
         }
 
         List<Faq> contents = queryFactory
-                .selectFrom(faq)
-                .join(faq.category).fetchJoin()
+                .selectDistinct(faq)
+                .from(faq)
+                .join(faq.faqCategories, fc)
+                .join(fc.category, category).fetchJoin()
                 .where(where)
                 .orderBy(faq.updatedDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
+        // count 쿼리
         Long total = queryFactory
-                .select(faq.count())
+                .select(faq.countDistinct())
                 .from(faq)
+                .join(faq.faqCategories, fc)
                 .where(where)
                 .fetchOne();
 

--- a/src/main/java/com/better/CommuteMate/domain/faq/repository/FaqRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/repository/FaqRepository.java
@@ -9,8 +9,6 @@ import java.util.List;
 @Repository
 public interface FaqRepository extends JpaRepository<Faq, Long>, FaqQueryRepository {
 
-    boolean existsByCategoryId(Long categoryId);
-
     // 제목에 특정 키워드가 포함된 FAQ 검색 (부분 일치)
     List<Faq> findByTitleContaining(String keyword);
 

--- a/src/main/java/com/better/CommuteMate/faq/application/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/FaqService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -45,8 +46,19 @@ public class FaqService {
         User writer = userRepository.findById(userId)
                 .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));
 
-        Category category = categoryRepository.findById(request.categoryId())
-                .orElseThrow(() -> CustomException.of(CategoryErrorCode.CATEGORY_NOT_FOUND));
+        if (request.categoryIds() == null || request.categoryIds().isEmpty()) {
+            throw CustomException.of(FaqErrorCode.CATEGORY_REQUIRED);
+        }
+
+        if (request.categoryIds().size() > 3) {
+            throw CustomException.of(FaqErrorCode.CATEGORY_LIMIT_EXCEEDED);
+        }
+
+        List<Category> categories = categoryRepository.findAllById(request.categoryIds());
+
+        if (categories.size() != request.categoryIds().size()) {
+            throw CustomException.of(CategoryErrorCode.CATEGORY_NOT_FOUND);
+        }
 
         Faq faq = Faq.create(
                 request.title(),
@@ -54,7 +66,7 @@ public class FaqService {
                 request.content(),
                 request.answer(),
                 request.etc(),
-                category,
+                categories,
                 writer
         );
 
@@ -77,10 +89,19 @@ public class FaqService {
             throw CustomException.of(FaqErrorCode.FAQ_ALREADY_DELETED);
         }
 
-        Category category = faq.getCategory();
-        if (request.categoryId() != null) {
-            category = categoryRepository.findById(request.categoryId())
-                    .orElseThrow(() -> CustomException.of(CategoryErrorCode.CATEGORY_NOT_FOUND));
+        List<Category> categories = new ArrayList<>();
+
+        if (request.categoryIds() != null && !request.categoryIds().isEmpty()) {
+
+            if (request.categoryIds().size() > 3) {
+                throw CustomException.of(FaqErrorCode.CATEGORY_LIMIT_EXCEEDED);
+            }
+
+            categories = categoryRepository.findAllById(request.categoryIds());
+
+            if (categories.size() != request.categoryIds().size()) {
+                throw CustomException.of(CategoryErrorCode.CATEGORY_NOT_FOUND);
+            }
         }
 
         faq.update(
@@ -89,7 +110,7 @@ public class FaqService {
                 request.content(),
                 request.answer(),
                 request.etc(),
-                category,
+                categories,
                 modifier
         );
 

--- a/src/main/java/com/better/CommuteMate/faq/application/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/FaqService.java
@@ -47,10 +47,6 @@ public class FaqService {
         User writer = userRepository.findById(userId)
                 .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));
 
-        if (request.categoryIds() == null || request.categoryIds().isEmpty()) {
-            throw CustomException.of(FaqErrorCode.CATEGORY_REQUIRED);
-        }
-
         if (request.categoryIds().size() > 3) {
             throw CustomException.of(FaqErrorCode.CATEGORY_LIMIT_EXCEEDED);
         }

--- a/src/main/java/com/better/CommuteMate/faq/application/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/FaqService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -72,7 +73,12 @@ public class FaqService {
 
         faqRepository.save(faq);
 
+        String categoryNames = categories.stream()
+                .map(Category::getName)
+                .collect(Collectors.joining(", "));
+
         FaqHistory faqhistory = FaqHistory.create(faq);
+
         faqHistoryRepository.save(faqhistory);
 
         return new PostFaqResponse(faq.getId());

--- a/src/main/java/com/better/CommuteMate/faq/application/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/FaqService.java
@@ -69,10 +69,6 @@ public class FaqService {
 
         faqRepository.save(faq);
 
-        String categoryNames = categories.stream()
-                .map(Category::getName)
-                .collect(Collectors.joining(", "));
-
         FaqHistory faqhistory = FaqHistory.create(faq);
 
         faqHistoryRepository.save(faqhistory);

--- a/src/main/java/com/better/CommuteMate/faq/application/dto/request/PostFaqRequest.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/dto/request/PostFaqRequest.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
 @Schema(description = "FAQ 등록 요청 DTO")
 public record PostFaqRequest(
         @NotBlank
@@ -21,8 +23,8 @@ public record PostFaqRequest(
         String etc,
 
         @NotNull
-        @Schema(description = "분류 id", example = "1")
-        Long categoryId,
+        @Schema(description = "분류 id 목록 (최대 3개)", example = "[1, 2, 3]")
+        List<Long> categoryIds,
 
         @Schema(description = "내용", example = "학정시 로그인을 하려는데 OTP 관련 메시지가 뜸")
         String content

--- a/src/main/java/com/better/CommuteMate/faq/application/dto/request/PostFaqRequest.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/dto/request/PostFaqRequest.java
@@ -2,27 +2,30 @@ package com.better.CommuteMate.faq.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 @Schema(description = "FAQ 등록 요청 DTO")
 public record PostFaqRequest(
-        @NotBlank
+
+        @NotBlank(message = "제목은 필수 입력값입니다.")
         @Schema(description = "제목", example = "학정시 로그인 오류")
         String title,
 
         @Schema(description = "민원인 이름", example = "홍길동")
         String complainantName,
 
-        @NotBlank
+        @NotBlank(message = "답변은 필수 입력값입니다.")
         @Schema(description = "답변", example = "핸드폰 앱에서 실행 안되고 ...")
         String answer,
 
         @Schema(description = "비고", example = "버튼 위치 변경됨")
         String etc,
 
-        @NotNull
+        @NotEmpty(message = "카테고리는 최소 1개 이상 선택해야 합니다.")
+        @Size(max = 3, message = "카테고리는 최대 3개까지 가능합니다.")
         @Schema(description = "분류 id 목록 (최대 3개)", example = "[1, 2, 3]")
         List<Long> categoryIds,
 

--- a/src/main/java/com/better/CommuteMate/faq/application/dto/request/PutFaqUpdateRequest.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/dto/request/PutFaqUpdateRequest.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
 @Schema(description = "FAQ 수정 요청 DTO")
 public record PutFaqUpdateRequest(
         @NotBlank
@@ -21,8 +23,8 @@ public record PutFaqUpdateRequest(
         String etc,
 
         @NotNull
-        @Schema(description = "분류 id", example = "1")
-        Long categoryId,
+        @Schema(description = "분류 id 목록 (최대 3개)", example = "[1, 2, 3]")
+        List<Long> categoryIds,
 
         @Schema(description = "내용", example = "학정시 로그인을 하려는데 OTP 관련 메시지가 뜸")
         String content

--- a/src/main/java/com/better/CommuteMate/faq/application/dto/response/GetFaqDetailResponse.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/dto/response/GetFaqDetailResponse.java
@@ -14,52 +14,36 @@ import java.util.List;
 @Getter
 public class GetFaqDetailResponse extends ResponseDetail {
 
-    @Schema(description = "faq id", example = "1")
     private final Long faqId;
-
-    @Schema(description = "faq 제목", example = "학정시 로그인 오륲")
     private final String title;
 
-    @Schema(description = "카테고리 이름", example = "로그인")
-    private final String categoryName;
+    private final List<String> categoryNames;
 
-    @Schema(description = "faq 삭제 여부", example = "true")
     private final Boolean deletedFlag;
-
-    @Schema(description = "민원인 이름", example = "홍길동")
     private final String complainantName;
-
-    @Schema(description = "작성자 이름", example = "양지윤")
     private final String writerName;
-
-    @Schema(description = "답변 내용", example = "비밀번호 재설정 후 다시 로그인해주세요.")
     private final String answer;
-
-    @Schema(description = "비고", example = "반복 문의 발생")
     private final String etc;
 
-    @Schema(description = "수정 시점 기준 담당자 목록")
     private final List<ManagerSnapshot> pastManagers;
-
-    @Schema(description = "현재 기준 담당자 목록")
     private final List<ManagerSnapshot> currentManagers;
 
-    @Schema(description = "수정 날짜 목록", example = "[\"2024-11-01\", \"2024-11-10\"]")
     private final List<LocalDate> editedDates;
-
-    @Schema(description = "삭제 날짜", nullable = true, example = "2026-01-01")
     private final LocalDate deletedAt;
 
     public GetFaqDetailResponse(Faq faq, FaqHistory history, List<LocalDate> editedDates) {
         super();
         this.faqId = faq.getId();
         this.title = history.getTitle();
-        this.categoryName = history.getCategoryName();
+
+        this.categoryNames = history.getCategoryNames();
+
         this.deletedFlag = faq.getDeletedFlag();
         this.complainantName = history.getComplainantName();
         this.writerName = history.getWriterName();
         this.answer = history.getAnswer();
         this.etc = history.getEtc();
+
         this.pastManagers = history.getManagers()
                 .stream()
                 .map(snapshot -> new ManagerSnapshot(
@@ -68,13 +52,17 @@ public class GetFaqDetailResponse extends ResponseDetail {
                         snapshot.getCategoryName()
                 ))
                 .toList();
-        this.currentManagers = faq.getCategory().getManagers().stream()
+
+        this.currentManagers = faq.getFaqCategories()
+                .stream()
+                .flatMap(fc -> fc.getCategory().getManagers().stream())
                 .map(mc -> new ManagerSnapshot(
                         mc.getManager().getName(),
                         mc.getManager().getTeam().getName(),
                         mc.getCategory().getName()
                 ))
                 .toList();
+
         this.editedDates = editedDates;
         this.deletedAt = faq.getDeletedAt();
     }

--- a/src/main/java/com/better/CommuteMate/faq/application/dto/response/GetFaqDetailResponse.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/dto/response/GetFaqDetailResponse.java
@@ -14,21 +14,40 @@ import java.util.List;
 @Getter
 public class GetFaqDetailResponse extends ResponseDetail {
 
+    @Schema(description = "faq id", example = "1")
     private final Long faqId;
+
+    @Schema(description = "faq 제목", example = "학적시 로그인 오류")
     private final String title;
 
+    @Schema(description = "카테고리 이름 목록", example = "[\"로그인\", \"계정\"]")
     private final List<String> categoryNames;
 
+    @Schema(description = "faq 삭제 여부", example = "true")
     private final Boolean deletedFlag;
+
+    @Schema(description = "민원인 이름", example = "홍길동")
     private final String complainantName;
+
+    @Schema(description = "작성자 이름", example = "양지윤")
     private final String writerName;
+
+    @Schema(description = "답변 내용", example = "비밀번호 재설정 후 다시 로그인해주세요.")
     private final String answer;
+
+    @Schema(description = "비고", example = "반복 문의 발생")
     private final String etc;
 
+    @Schema(description = "과거 담당자 목록")
     private final List<ManagerSnapshot> pastManagers;
+
+    @Schema(description = "현재 담당자 목록")
     private final List<ManagerSnapshot> currentManagers;
 
+    @Schema(description = "수정 이력 날짜 목록", example = "[\"2024-03-01\", \"2024-03-05\"]")
     private final List<LocalDate> editedDates;
+
+    @Schema(description = "삭제 일자", example = "2024-03-10")
     private final LocalDate deletedAt;
 
     public GetFaqDetailResponse(Faq faq, FaqHistory history, List<LocalDate> editedDates) {

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/FaqErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/FaqErrorCode.java
@@ -10,7 +10,9 @@ public enum FaqErrorCode implements CustomErrorCode {
 
     FAQ_NOT_FOUND("존재하지 않는 FaqId입니다.", "[Error] : Faq를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     FAQ_ALREADY_DELETED("이미 삭제된 FAQ입니다.", "[Error] : 이미 삭제된 FAQ", HttpStatus.BAD_REQUEST),
-    INVALID_FAQ_HISTORY_DATE("해당 날짜의 FAQ 수정 이력이 존재하지 않습니다.", "[Error] : FAQ 히스토리 날짜 조회 실패", HttpStatus.BAD_REQUEST)
+    INVALID_FAQ_HISTORY_DATE("해당 날짜의 FAQ 수정 이력이 존재하지 않습니다.", "[Error] : FAQ 히스토리 날짜 조회 실패", HttpStatus.BAD_REQUEST),
+    CATEGORY_LIMIT_EXCEEDED("지정 가능한 카테고리 개수를 초과했습니다.", "[Error] : 카테고리 개수 초과", HttpStatus.BAD_REQUEST),
+    CATEGORY_REQUIRED("카테고리가 지정되지 않았습니다.", "[Error] : 카테고리 지정 누락", HttpStatus.BAD_REQUEST)
     ;
 
     private final String message;


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
<!-- 이 PR이 해결하려는 문제나 추가하려는 기능에 대해 간략히 설명해주세요. -->
<!-- - (예: "로그인 API에서 JWT 토큰 발급 로직 추가") -->
FAQ 작성 및 수정 시, 기존에는 하나의 카테고리만 선택 가능했던 것에서 최대 3개를 지정할 수 있도록 기능을 확장하였습니다.
이에 따라 엔티티 구조, 서비스 로직, QueryDSL 및 DTO 전반을 수정하였습니다.

## 2. 관련 이슈 🔗

<!--
(예: "Closes #123")
(예: "관련 이슈 없음")
-->
#81 

## 3. 주요 변경 사항 🔑

<!-- 어떤 부분이 변경되었는지 구체적으로 작성해주세요. -->

### **API 변경 사항 (해당하는 경우)**
<!--
  - [POST] /api/v1/auth/login: 신규 로그인 API 추가
  - [GET] /api/v1/users/{id}: 응답 DTO에 age 필드 추가
-->
1. FAQ 생성/수정 API에서 카테고리 입력 방식 변경
- 기존: categoryId (Long)
- 변경: categoryIds (List<Long>, 최대 3개)

2. FAQ 상세 조회 응답 변경
- 기존: categoryName (String)
- 변경: categoryNames (List<String>)


### **데이터베이스 변경 사항 (해당하는 경우)**
<!--
  - User 테이블에 age (int) 컬럼 추가 (migration_file_name.sql)
  - Product 테이블의 price 인덱스 추가
-->
1. FAQ - Category 관계 변경
- 기존: faq.category_id (N:1)
- 변경: faq_category 중간 테이블 추가 (N:M 구조)

2. 신규 테이블 생성
- faq_category
    - id
    - faq_id
    - category_id

3. FAQ 히스토리 변경
- 기존: category_name (String)
- 변경: faq_history_categories 테이블을 통한 다중 카테고리 저장


### **핵심 로직**
<!--
  - AuthService: JWT 토큰 생성 및 검증 로직 구현
  - UserService: 사용자 조회 시 캐시(Redis) 적용
-->
1. Faq 엔티티
- Category 단일 필드 제거 → List<FaqCategory>로 변경
- addCategory() 메서드 추가 (최대 3개 제한)
- create/update 로직을 리스트 기반으로 수정

2. FaqCategory 엔티티
- FAQ ↔ Category 연결을 위한 중간 엔티티 추가

3. Service (Create / Update)
- 단일 카테고리 → 다중 카테고리 처리 로직으로 변경
- 카테고리 존재 여부 및 개수 제한 검증 추가

4. FaqHistory
- 카테고리 및 담당자 스냅샷을 다중 구조로 저장하도록 수정

5. QueryDSL
- 기존 faq.category 기반 조회 제거
- faq → faqCategories → category 구조로 join 수정
- selectDistinct 및 countDistinct 적용 (중복 방지)

6. Repository
- existsByCategoryId 제거
- existsByCategory_Id (FaqCategoryRepository)로 변경


## 4. 중점 리뷰 요청 사항 💡

<!--
리뷰어가 특별히 더 신경 써서 봐주었으면 하는 부분을 작성해주세요.
(예: "AuthService의 토큰 만료 시간 설정이 적절한지 확인 부탁드립니다.")
(예: "UserService에 N+1 쿼리 문제가 없는지 확인해주세요.")
(예: "새로 추가한 API의 예외 처리 로직이 충분한지 검토해주세요.")
-->

## 5. 스크린샷 또는 테스트 결과 📸
- 카테고리 2개 지정
<img width="2166" height="1584" alt="image" src="https://github.com/user-attachments/assets/15a5a79f-e2ac-443c-92ba-18bbf71b841a" />

- 카테고리 3개 지정
<img width="2188" height="1604" alt="image" src="https://github.com/user-attachments/assets/8064bd5d-0a14-4515-8d51-c0dc2136eb94" />

- 카테고리 4개 지정 (예외)
<img width="2202" height="1448" alt="image" src="https://github.com/user-attachments/assets/3d294edb-946f-4f5d-bd45-9ac7f0e3e04f" />

- 카테고리 지정 X (예외)
<img width="2204" height="1334" alt="image" src="https://github.com/user-attachments/assets/854ba772-6206-43b8-92e8-a6354aa32222" />

