### PR TITLE
[FEAT] FAQ 임시저장 기능 구현

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -129,7 +129,7 @@ public class Faq {
         return faq;
     }
 
-    public void update( // Todo FaqStatus 추가하기
+    public void update(
             String title,
             String complainantName,
             String content,

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -136,7 +136,8 @@ public class Faq {
             String answer,
             String etc,
             List<Category> categories,
-            User writer
+            User writer,
+            FaqStatus status
     ) {
         this.title = title;
         this.complainantName = complainantName;
@@ -144,6 +145,7 @@ public class Faq {
         this.answer = answer;
         this.etc = etc;
         this.writer = writer;
+        this.status = status;
 
         this.faqCategories.clear();
 

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -55,6 +55,10 @@ public class Faq {
     @Column(name = "deleted_at")
     private LocalDate deletedAt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FaqStatus status;
+
     @OneToMany(mappedBy = "faq", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FaqImage> images = new ArrayList<>();
 

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -103,7 +103,7 @@ public class Faq {
         this.updatedDate = LocalDate.now();
     }
 
-    public static Faq create(
+    public static Faq create( // Todo FaqStatus 추가하기
             String title,
             String complainantName,
             String content,
@@ -127,7 +127,7 @@ public class Faq {
         return faq;
     }
 
-    public void update(
+    public void update( // Todo FaqStatus 추가하기
             String title,
             String complainantName,
             String content,

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -103,14 +103,15 @@ public class Faq {
         this.updatedDate = LocalDate.now();
     }
 
-    public static Faq create( // Todo FaqStatus 추가하기
+    public static Faq create(
             String title,
             String complainantName,
             String content,
             String answer,
             String etc,
             List<Category> categories,
-            User writer
+            User writer,
+            FaqStatus status
     ) {
         Faq faq = new Faq();
         faq.title = title;
@@ -119,6 +120,7 @@ public class Faq {
         faq.answer = answer;
         faq.etc = etc;
         faq.writer = writer;
+        faq.status = status;
 
         for (Category category : categories) {
             faq.addCategory(category);

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -40,8 +40,8 @@ public class Faq {
     private String etc;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "writer_id")
-    private User writer; // Todo nullable=true로 수정 완료
+    @JoinColumn(name = "writer_id", nullable = false)
+    private User writer;
 
     @OneToMany(mappedBy = "faq", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FaqCategory> faqCategories = new ArrayList<>();

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/Faq.java
@@ -24,24 +24,24 @@ public class Faq {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 30, nullable = false)
-    private String title;
+    @Column(length = 30)
+    private String title; // Todo nullable=true로 수정 완료
 
     @Column(name = "complainant_name", length = 50)
     private String complainantName;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String content;
+    @Column(columnDefinition = "TEXT")
+    private String content; // Todo nullable=true로 수정 완료
 
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String answer;
+    @Column(columnDefinition = "TEXT")
+    private String answer; // Todo nullable=true로 수정 완료
 
     @Column(columnDefinition = "TEXT")
     private String etc;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "writer_id", nullable = false)
-    private User writer;
+    @JoinColumn(name = "writer_id")
+    private User writer; // Todo nullable=true로 수정 완료
 
     @OneToMany(mappedBy = "faq", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FaqCategory> faqCategories = new ArrayList<>();

--- a/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqStatus.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/entity/FaqStatus.java
@@ -1,0 +1,6 @@
+package com.better.CommuteMate.domain.faq.entity;
+
+public enum FaqStatus {
+    DRAFT,
+    PUBLISHED
+}

--- a/src/main/java/com/better/CommuteMate/domain/faq/repository/FaqQueryRepositoryImpl.java
+++ b/src/main/java/com/better/CommuteMate/domain/faq/repository/FaqQueryRepositoryImpl.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import com.better.CommuteMate.domain.faq.entity.FaqStatus;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -53,6 +54,7 @@ public class FaqQueryRepositoryImpl implements FaqQueryRepository {
         BooleanBuilder where = new BooleanBuilder();
 
         where.and(faq.deletedFlag.isFalse());
+        where.and(faq.status.eq(FaqStatus.PUBLISHED));
 
         if (categoryId != null) {
             where.and(fc.category.id.eq(categoryId));
@@ -153,6 +155,7 @@ public class FaqQueryRepositoryImpl implements FaqQueryRepository {
             FROM faq f
             LEFT JOIN faq_category fc ON f.id = fc.faq_id
             WHERE f.deleted_flag = false
+                AND f.status = 'PUBLISHED'
         """);
 
         if (categoryId != null) sql.append(" AND fc.category_id = :categoryId");

--- a/src/main/java/com/better/CommuteMate/faq/application/dto/request/PostDraftFaqRequest.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/dto/request/PostDraftFaqRequest.java
@@ -1,0 +1,28 @@
+package com.better.CommuteMate.faq.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "FAQ 임시저장 요청 DTO")
+public record PostDraftFaqRequest(
+
+        @Schema(description = "제목")
+        String title,
+
+        @Schema(description = "민원인 이름")
+        String complainantName,
+
+        @Schema(description = "내용")
+        String content,
+
+        @Schema(description = "답변")
+        String answer,
+
+        @Schema(description = "비고")
+        String etc,
+
+        @Schema(description = "카테고리 id 목록")
+        List<Long> categoryIds
+) {
+}

--- a/src/main/java/com/better/CommuteMate/faq/application/dto/request/PutDraftFaqUpdateRequest.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/dto/request/PutDraftFaqUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.better.CommuteMate.faq.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "FAQ 임시저장 수정 요청 DTO")
+public record PutDraftFaqUpdateRequest(
+
+        @Schema(description = "제목", example = "로그인 오류 문의")
+        String title,
+
+        @Schema(description = "민원인 이름", example = "홍길동")
+        String complainantName,
+
+        @Schema(description = "질문 내용", example = "<p>질문 내용입니다.</p>")
+        String content,
+
+        @Schema(description = "답변 내용", example = "<p>답변 내용입니다.</p>")
+        String answer,
+
+        @Schema(description = "비고", example = "추가 메모")
+        String etc,
+
+        @Schema(description = "카테고리 ID 목록", example = "[1, 2]")
+        List<Long> categoryIds
+) {
+}

--- a/src/main/java/com/better/CommuteMate/faq/application/dto/response/PostFaqResponse.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/dto/response/PostFaqResponse.java
@@ -1,5 +1,6 @@
 package com.better.CommuteMate.faq.application.dto.response;
 
+import com.better.CommuteMate.domain.faq.entity.FaqStatus;
 import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -9,9 +10,11 @@ import lombok.Getter;
 public class PostFaqResponse extends ResponseDetail {
     @Schema(description = "등록된 FAQ ID", example = "1")
     Long faqId;
+    FaqStatus status;
 
-    public PostFaqResponse(Long faqId) {
+    public PostFaqResponse(Long faqId,  FaqStatus status) {
         super();
         this.faqId = faqId;
+        this.status = status;
     }
 }

--- a/src/main/java/com/better/CommuteMate/faq/application/dto/response/PutFaqUpdateResponse.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/dto/response/PutFaqUpdateResponse.java
@@ -1,5 +1,6 @@
 package com.better.CommuteMate.faq.application.dto.response;
 
+import com.better.CommuteMate.domain.faq.entity.FaqStatus;
 import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -9,10 +10,12 @@ import lombok.Getter;
 public class PutFaqUpdateResponse extends ResponseDetail {
     @Schema(description = "수정된 FAQ ID", example = "1")
     Long faqId;
+    FaqStatus faqStatus;
 
-    public PutFaqUpdateResponse(Long faqId) {
+    public PutFaqUpdateResponse(Long faqId,  FaqStatus faqStatus) {
         super();
         this.faqId = faqId;
+        this.faqStatus = faqStatus;
     }
 }
 

--- a/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
@@ -10,10 +10,7 @@ import com.better.CommuteMate.domain.faq.repository.FaqRelationRepository;
 import com.better.CommuteMate.domain.faq.repository.FaqRepository;
 import com.better.CommuteMate.domain.user.entity.User;
 import com.better.CommuteMate.domain.user.repository.UserRepository;
-import com.better.CommuteMate.faq.application.dto.request.FaqSearchScope;
-import com.better.CommuteMate.faq.application.dto.request.PostDraftFaqRequest;
-import com.better.CommuteMate.faq.application.dto.request.PostFaqRequest;
-import com.better.CommuteMate.faq.application.dto.request.PutFaqUpdateRequest;
+import com.better.CommuteMate.faq.application.dto.request.*;
 import com.better.CommuteMate.faq.application.dto.response.GetFaqDetailResponse;
 import com.better.CommuteMate.faq.application.dto.response.GetFaqListResponse;
 import com.better.CommuteMate.faq.application.dto.response.GetFaqListWrapper;
@@ -246,10 +243,59 @@ public class FaqService {
         );
     }
 
-    public void updateDraftFaq(Long userId, Long faqId) {
-        // Todo draft faq 수정 함수
-        // Todo dto 추가
-        // Todo set status = draft
+    public PutFaqUpdateResponse updateDraftFaq(Long userId, Long faqId, PutDraftFaqUpdateRequest request) {
+
+        User modifier = userRepository.findById(userId)
+                .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));
+
+        Faq faq = faqRepository.findById(faqId)
+                .orElseThrow(() -> CustomException.of(FaqErrorCode.FAQ_NOT_FOUND));
+
+        if (Boolean.TRUE.equals(faq.getDeletedFlag())) {
+            throw CustomException.of(FaqErrorCode.FAQ_ALREADY_DELETED);
+        }
+
+        if (faq.getStatus() != FaqStatus.DRAFT) {
+            throw CustomException.of(FaqErrorCode.INVALID_FAQ_STATUS);
+        }
+
+        List<Category> categories = new ArrayList<>();
+
+        // 카테고리가 넘어온 경우에만 검증
+        if (request.categoryIds() != null && !request.categoryIds().isEmpty()) {
+
+            if (request.categoryIds().size() > 3) {
+                throw CustomException.of(FaqErrorCode.CATEGORY_LIMIT_EXCEEDED);
+            }
+
+            categories = categoryRepository.findAllById(request.categoryIds());
+
+            if (categories.size() != request.categoryIds().size()) {
+                throw CustomException.of(CategoryErrorCode.CATEGORY_NOT_FOUND);
+            }
+        }
+
+        faq.update(
+                request.title(),
+                request.complainantName(),
+                request.content(),
+                request.answer(),
+                request.etc(),
+                categories,
+                modifier,
+                FaqStatus.DRAFT // 드래프트 유지
+        );
+
+        List<String> imageUrls = extractImageUrls(request.content(), request.answer());
+
+        faq.getImages().clear();
+
+        if (!imageUrls.isEmpty()) {
+            List<FaqImage> images = faqImageRepository.findByUrlIn(imageUrls);
+            images.forEach(faq::addImage);
+        }
+
+        return new PutFaqUpdateResponse(faq.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
@@ -2,10 +2,7 @@ package com.better.CommuteMate.faq.application.service;
 
 import com.better.CommuteMate.domain.category.entity.Category;
 import com.better.CommuteMate.domain.category.repository.CategoryRepository;
-import com.better.CommuteMate.domain.faq.entity.Faq;
-import com.better.CommuteMate.domain.faq.entity.FaqFile;
-import com.better.CommuteMate.domain.faq.entity.FaqHistory;
-import com.better.CommuteMate.domain.faq.entity.FaqImage;
+import com.better.CommuteMate.domain.faq.entity.*;
 import com.better.CommuteMate.domain.faq.repository.FaqFileRepository;
 import com.better.CommuteMate.domain.faq.repository.FaqHistoryRepository;
 import com.better.CommuteMate.domain.faq.repository.FaqImageRepository;
@@ -65,6 +62,7 @@ public class FaqService {
     private final OpenAIEmbeddingClient embeddingClient;
     private final FaqRelationRepository faqRelationRepository;
 
+    // 생성 후 Publish
     public PostFaqResponse createFaq(Long userId, PostFaqRequest request) {
 
         User writer = userRepository.findById(userId)
@@ -87,7 +85,8 @@ public class FaqService {
                 request.answer(),
                 request.etc(),
                 categories,
-                writer
+                writer,
+                FaqStatus.PUBLISHED
         );
 
         faqRepository.save(faq);
@@ -122,6 +121,7 @@ public class FaqService {
         return new PostFaqResponse(faq.getId());
     }
 
+    // 수정 후 Publish
     public PutFaqUpdateResponse updateFaq(Long userId, Long faqId, PutFaqUpdateRequest request) {
         User modifier = userRepository.findById(userId)
                 .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
@@ -119,7 +119,7 @@ public class FaqService {
 
         computeAndSaveEmbedding(faq);
 
-        return new PostFaqResponse(faq.getId());
+        return new PostFaqResponse(faq.getId(), faq.getStatus());
     }
 
     // faq 수정 후 발행, set status = Publish
@@ -241,8 +241,8 @@ public class FaqService {
         }
 
         return new PostFaqResponse(
-                faq.getId()
-                // Todo status 정보 추가하기
+                faq.getId(),
+                faq.getStatus()
         );
     }
 

--- a/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
@@ -155,7 +155,8 @@ public class FaqService {
                 request.answer(),
                 request.etc(),
                 categories,
-                modifier
+                modifier,
+                FaqStatus.PUBLISHED
         );
 
         faq.getImages().forEach(FaqImage::detachFaq);

--- a/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
@@ -193,7 +193,7 @@ public class FaqService {
 
         computeAndSaveEmbedding(faq);
 
-        return new PutFaqUpdateResponse(faqId);
+        return new PutFaqUpdateResponse(faqId, faq.getStatus());
     }
 
     public PostFaqResponse createDraftFaq(Long userId, PostDraftFaqRequest request) {
@@ -295,7 +295,7 @@ public class FaqService {
             images.forEach(faq::addImage);
         }
 
-        return new PutFaqUpdateResponse(faq.getId());
+        return new PutFaqUpdateResponse(faq.getId(), faq.getStatus());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
@@ -11,6 +11,7 @@ import com.better.CommuteMate.domain.faq.repository.FaqRepository;
 import com.better.CommuteMate.domain.user.entity.User;
 import com.better.CommuteMate.domain.user.repository.UserRepository;
 import com.better.CommuteMate.faq.application.dto.request.FaqSearchScope;
+import com.better.CommuteMate.faq.application.dto.request.PostDraftFaqRequest;
 import com.better.CommuteMate.faq.application.dto.request.PostFaqRequest;
 import com.better.CommuteMate.faq.application.dto.request.PutFaqUpdateRequest;
 import com.better.CommuteMate.faq.application.dto.response.GetFaqDetailResponse;
@@ -62,7 +63,7 @@ public class FaqService {
     private final OpenAIEmbeddingClient embeddingClient;
     private final FaqRelationRepository faqRelationRepository;
 
-    // 생성 후 Publish
+    // faq 객체 생성, set status = Publish
     public PostFaqResponse createFaq(Long userId, PostFaqRequest request) {
 
         User writer = userRepository.findById(userId)
@@ -121,7 +122,7 @@ public class FaqService {
         return new PostFaqResponse(faq.getId());
     }
 
-    // 수정 후 Publish
+    // faq 수정 후 발행, set status = Publish
     public PutFaqUpdateResponse updateFaq(Long userId, Long faqId, PutFaqUpdateRequest request) {
         User modifier = userRepository.findById(userId)
                 .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));
@@ -196,6 +197,59 @@ public class FaqService {
         computeAndSaveEmbedding(faq);
 
         return new PutFaqUpdateResponse(faqId);
+    }
+
+    public PostFaqResponse createDraftFaq(Long userId, PostDraftFaqRequest request) {
+
+        User writer = userRepository.findById(userId)
+                .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));
+
+        List<Category> categories = new ArrayList<>();
+
+        // 카테고리가 넘어온 경우에만 검증
+        if (request.categoryIds() != null && !request.categoryIds().isEmpty()) {
+
+            if (request.categoryIds().size() > 3) {
+                throw CustomException.of(FaqErrorCode.CATEGORY_LIMIT_EXCEEDED);
+            }
+
+            categories = categoryRepository.findAllById(request.categoryIds());
+
+            if (categories.size() != request.categoryIds().size()) {
+                throw CustomException.of(CategoryErrorCode.CATEGORY_NOT_FOUND);
+            }
+        }
+
+        Faq faq = Faq.create(
+                request.title(),
+                request.complainantName(),
+                request.content(),
+                request.answer(),
+                request.etc(),
+                categories,
+                writer,
+                FaqStatus.DRAFT
+        );
+
+        faqRepository.save(faq);
+
+        List<String> imageUrls = extractImageUrls(request.content(), request.answer());
+
+        if (!imageUrls.isEmpty()) {
+            List<FaqImage> images = faqImageRepository.findByUrlIn(imageUrls);
+            images.forEach(faq::addImage);
+        }
+
+        return new PostFaqResponse(
+                faq.getId()
+                // Todo status 정보 추가하기
+        );
+    }
+
+    public void updateDraftFaq(Long userId, Long faqId) {
+        // Todo draft faq 수정 함수
+        // Todo dto 추가
+        // Todo set status = draft
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
+++ b/src/main/java/com/better/CommuteMate/faq/application/service/FaqService.java
@@ -196,6 +196,7 @@ public class FaqService {
         return new PutFaqUpdateResponse(faqId, faq.getStatus());
     }
 
+    // faq 최초 임시저장, faq 객체 생성, set status = Draft
     public PostFaqResponse createDraftFaq(Long userId, PostDraftFaqRequest request) {
 
         User writer = userRepository.findById(userId)
@@ -243,6 +244,7 @@ public class FaqService {
         );
     }
 
+    // faq 임시저장 이후 수정 그리고 또 다시 임시저장, set status = Draft
     public PutFaqUpdateResponse updateDraftFaq(Long userId, Long faqId, PutDraftFaqUpdateRequest request) {
 
         User modifier = userRepository.findById(userId)

--- a/src/main/java/com/better/CommuteMate/faq/controller/FaqController.java
+++ b/src/main/java/com/better/CommuteMate/faq/controller/FaqController.java
@@ -33,8 +33,8 @@ public class FaqController {
     private final FaqService faqService;
 
     @Operation(
-            summary = "FAQ 작성",
-            description = "FAQ 작성을 위한 API입니다."
+            summary = "FAQ 작성 후 발행",
+            description = "FAQ 작성 후 바로 발행 버튼을 눌렀을 때를 위한 API입니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "FAQ 작성 성공"),
@@ -51,7 +51,7 @@ public class FaqController {
     }
 
     @Operation(
-            summary = "FAQ 수정",
+            summary = "FAQ 수정 후 발행",
             description = """
                     특정 FAQ를 수정하는 API입니다.
                     수정 시 기존 내용은 faq_history 테이블에 기록되고,
@@ -77,7 +77,7 @@ public class FaqController {
 
     @Operation(
             summary = "FAQ 최초 임시저장",
-            description = "FAQ 객체를 생성하고, 임시저장하는 API입니다."
+            description = "FAQ 객체를 생성하고, 임시저장하는 API입니다. 즉, 처음으로 임시저장을 누를 때 사용됩니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "FAQ 임시저장 성공"),
@@ -100,8 +100,8 @@ public class FaqController {
     }
 
     @Operation(
-            summary = "FAQ 임시저장 수정",
-            description = "임시저장된 FAQ를 수정하기 위한 API입니다."
+            summary = "FAQ 수정 후 임시저장",
+            description = "임시저장된 FAQ를 수정한 이후, 또 임시저장할 때 사용하는 API입니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "FAQ 임시저장 수정 성공"),

--- a/src/main/java/com/better/CommuteMate/faq/controller/FaqController.java
+++ b/src/main/java/com/better/CommuteMate/faq/controller/FaqController.java
@@ -1,10 +1,7 @@
 package com.better.CommuteMate.faq.controller;
 
 import com.better.CommuteMate.auth.application.CustomUserDetails;
-import com.better.CommuteMate.faq.application.dto.request.FaqSearchScope;
-import com.better.CommuteMate.faq.application.dto.request.PostDraftFaqRequest;
-import com.better.CommuteMate.faq.application.dto.request.PostFaqRequest;
-import com.better.CommuteMate.faq.application.dto.request.PutFaqUpdateRequest;
+import com.better.CommuteMate.faq.application.dto.request.*;
 import com.better.CommuteMate.faq.application.service.FaqService;
 import com.better.CommuteMate.faq.application.dto.response.GetFaqDetailResponse;
 import com.better.CommuteMate.faq.application.dto.response.GetFaqListWrapper;
@@ -98,6 +95,31 @@ public class FaqController {
                         true,
                         "FAQ 최초 임시저장 성공",
                         faqService.createDraftFaq(userDetails.getUserId(), request)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "FAQ 임시저장 수정",
+            description = "임시저장된 FAQ를 수정하기 위한 API입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "FAQ 임시저장 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PutMapping("/draft/{faqId}")
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> updateDraftFaq(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long faqId,
+            @RequestBody PutDraftFaqUpdateRequest request
+    ) {
+        return ResponseEntity.ok(
+                new Response(
+                        true,
+                        "FAQ 임시저장 수정 성공",
+                        faqService.updateDraftFaq(userDetails.getUserId(), faqId, request)
                 )
         );
     }

--- a/src/main/java/com/better/CommuteMate/faq/controller/FaqController.java
+++ b/src/main/java/com/better/CommuteMate/faq/controller/FaqController.java
@@ -2,6 +2,7 @@ package com.better.CommuteMate.faq.controller;
 
 import com.better.CommuteMate.auth.application.CustomUserDetails;
 import com.better.CommuteMate.faq.application.dto.request.FaqSearchScope;
+import com.better.CommuteMate.faq.application.dto.request.PostDraftFaqRequest;
 import com.better.CommuteMate.faq.application.dto.request.PostFaqRequest;
 import com.better.CommuteMate.faq.application.dto.request.PutFaqUpdateRequest;
 import com.better.CommuteMate.faq.application.service.FaqService;
@@ -75,6 +76,30 @@ public class FaqController {
             @RequestBody PutFaqUpdateRequest request
     ) {
         return ResponseEntity.ok(new Response(true, "FAQ 수정 성공", faqService.updateFaq(userDetails.getUserId(), faqId, request)));
+    }
+
+    @Operation(
+            summary = "FAQ 최초 임시저장",
+            description = "FAQ 객체를 생성하고, 임시저장하는 API입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "FAQ 임시저장 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/draft")
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> createDraftFaq(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody PostDraftFaqRequest request
+    ) {
+        return ResponseEntity.ok(
+                new Response(
+                        true,
+                        "FAQ 최초 임시저장 성공",
+                        faqService.createDraftFaq(userDetails.getUserId(), request)
+                )
+        );
     }
 
     @Operation(

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/FaqErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/FaqErrorCode.java
@@ -13,7 +13,8 @@ public enum FaqErrorCode implements CustomErrorCode {
     INVALID_FAQ_HISTORY_DATE("해당 날짜의 FAQ 수정 이력이 존재하지 않습니다.", "[Error] : FAQ 히스토리 날짜 조회 실패", HttpStatus.BAD_REQUEST),
     CATEGORY_LIMIT_EXCEEDED("지정 가능한 카테고리 개수를 초과했습니다.", "[Error] : 카테고리 개수 초과", HttpStatus.BAD_REQUEST),
     CATEGORY_REQUIRED("카테고리가 지정되지 않았습니다.", "[Error] : 카테고리 지정 누락", HttpStatus.BAD_REQUEST),
-    RELATED_FAQ_NOT_FOUND("존재하지 않는 관련 FaqId입니다.", "[Error] : 관련 Faq를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+    RELATED_FAQ_NOT_FOUND("존재하지 않는 관련 FaqId입니다.", "[Error] : 관련 Faq를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_FAQ_STATUS("적합하지 않은 FAQ Status입니다.", "[Error] : FAQ status 부적합", HttpStatus.BAD_REQUEST)
     ;
 
     private final String message;


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
FAQ 임시저장(Draft) 기능을 구현하고, FAQ 상태(DRAFT/PUBLISHED) 필드를 추가하였습니다.

## 2. 관련 이슈 🔗
#84 #103 

## 3. 주요 변경 사항 🔑
- FAQ 임시저장 API 2개 추가 (`POST /api/faq/draft`), (`PUT /api/faq/draft/{faqId}`)
- FAQ 상태(`DRAFT`, `PUBLISHED`) 기반 관리 기능 추가
- FAQ Entity 수정

## 4. 기타 💬
- 로컬 DB 스키마(`embedding` 컬럼, nullable 제약 등)가 최신 상태(코드와 nullable 제약이 동일한 상태)인지 확인 후 테스트해주세요.