### PR TITLE
[FEAT] admin 근로신청 관리 api 구현

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
@@ -66,6 +66,22 @@ public interface WorkSchedulesRepository extends JpaRepository<WorkSchedule, Str
             CodeType statusCode
     );
 
+    boolean existsByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeIn(
+            Long userId,
+            LocalDate date,
+            LocalTime startTime,
+            LocalTime endTime,
+            List<CodeType> statusCodes
+    );
+
+    long countBySettingAndDateAndStartTimeAndEndTimeAndStatusCode(
+            WorkScheduleSetting setting,
+            LocalDate date,
+            LocalTime startTime,
+            LocalTime endTime,
+            CodeType statusCode
+    );
+
     /**
      * 특정 사용자와 특정 날짜, 시작 시간을 기준으로 근무 일정을 조회
      */

--- a/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
@@ -15,6 +15,20 @@ import java.util.Optional;
 @Repository
 public interface WorkSchedulesRepository extends JpaRepository<WorkSchedule, String> {
 
+    Optional<WorkSchedule> findByScheduleIdAndUser_OrganizationIdAndStatusCodeIn(
+            String scheduleId,
+            Long organizationId,
+            List<CodeType> statusCodes
+    );
+
+    Optional<WorkSchedule> findFirstByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeOrderByUpdatedAtDesc(
+            Long userId,
+            LocalDate date,
+            LocalTime startTime,
+            LocalTime endTime,
+            CodeType statusCode
+    );
+
     /**
      * 특정 날짜의 근무 일정 목록을 조회
      */

--- a/src/main/java/com/better/CommuteMate/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/user/repository/UserRepository.java
@@ -1,8 +1,10 @@
 package com.better.CommuteMate.domain.user.repository;
 
 import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.global.code.CodeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -10,5 +12,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByUserId(Long userId);
     Optional<User> findByUserIdAndOrganizationId(Long userId, Long organizationId);
+    List<User> findAllByOrganizationIdAndRoleCodeAndNameContainingIgnoreCaseOrderByNameAscUserIdAsc(
+            Long organizationId,
+            CodeType roleCode,
+            String name
+    );
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/better/CommuteMate/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/user/repository/UserRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByUserId(Long userId);
+    Optional<User> findByUserIdAndOrganizationId(Long userId, Long organizationId);
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/better/CommuteMate/domain/workattendance/repository/WorkAttendanceRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/workattendance/repository/WorkAttendanceRepository.java
@@ -11,5 +11,6 @@ import java.util.List;
 public interface WorkAttendanceRepository extends JpaRepository<WorkAttendance, Integer> {
     List<WorkAttendance> findByUser_UserIdAndCheckTime(Long userId, LocalDateTime checkTime);
     List<WorkAttendance> findBySchedule_ScheduleId(String scheduleId);
+    boolean existsBySchedule_ScheduleId(String scheduleId);
     List<WorkAttendance> findByUser_UserIdAndCheckTimeBetween(Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
@@ -9,6 +9,8 @@ public enum ScheduleErrorCode implements CustomErrorCode {
     ADMIN_WORK_ASSIGNMENT_WORKPLACE_NOT_FOUND("조직의 근무지를 찾을 수 없습니다.", "[Error] : admin work assignment workplace not found", HttpStatus.NOT_FOUND),
     ADMIN_WORK_SCHEDULE_NOT_FOUND("근로 시간표를 찾을 수 없습니다.", "[Error] : admin work schedule not found", HttpStatus.NOT_FOUND),
     ADMIN_WORK_SCHEDULE_HAS_ATTENDANCE("출퇴근 기록이 있어 삭제할 수 없습니다.", "[Error] : admin work schedule has attendance", HttpStatus.CONFLICT),
+    ADMIN_WORK_SCHEDULE_USER_NOT_FOUND("사용자를 찾을 수 없습니다.", "[Error] : admin work schedule user not found", HttpStatus.BAD_REQUEST),
+    ADMIN_WORK_SCHEDULE_INVALID_RANGE("조회 기간이 올바르지 않습니다.", "[Error] : invalid admin work schedule range", HttpStatus.BAD_REQUEST),
     INVALID_CHANGE_REQUEST_IDS("요청 ID 목록이 올바르지 않습니다.", "[Error] : invalid change request ids", HttpStatus.BAD_REQUEST),
     INVALID_CHANGE_REQUEST_PROCESS_STATUS("올바르지 않은 처리 상태입니다.", "[Error] : invalid change request process status", HttpStatus.BAD_REQUEST),
     CHANGE_REQUEST_REJECT_REASON_REQUIRED("거절 사유를 입력해야 합니다.", "[Error] : change request reject reason required", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
@@ -3,6 +3,10 @@ package com.better.CommuteMate.global.exceptions.error;
 import org.springframework.http.HttpStatus;
 
 public enum ScheduleErrorCode implements CustomErrorCode {
+    INVALID_ADMIN_WORK_ASSIGNMENT_TIME("근로 시간은 30분 단위로만 지정할 수 있습니다.", "[Error] : invalid admin work assignment time", HttpStatus.BAD_REQUEST),
+    ADMIN_WORK_ASSIGNMENT_USER_NOT_FOUND("사용자를 찾을 수 없습니다.", "[Error] : admin work assignment user not found", HttpStatus.BAD_REQUEST),
+    ADMIN_WORK_ASSIGNMENT_DUPLICATED("이미 해당 시간에 배치된 사용자입니다.", "[Error] : duplicated admin work assignment", HttpStatus.CONFLICT),
+    ADMIN_WORK_ASSIGNMENT_WORKPLACE_NOT_FOUND("조직의 근무지를 찾을 수 없습니다.", "[Error] : admin work assignment workplace not found", HttpStatus.NOT_FOUND),
     INVALID_CHANGE_REQUEST_IDS("요청 ID 목록이 올바르지 않습니다.", "[Error] : invalid change request ids", HttpStatus.BAD_REQUEST),
     INVALID_CHANGE_REQUEST_PROCESS_STATUS("올바르지 않은 처리 상태입니다.", "[Error] : invalid change request process status", HttpStatus.BAD_REQUEST),
     CHANGE_REQUEST_REJECT_REASON_REQUIRED("거절 사유를 입력해야 합니다.", "[Error] : change request reject reason required", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
@@ -7,6 +7,8 @@ public enum ScheduleErrorCode implements CustomErrorCode {
     ADMIN_WORK_ASSIGNMENT_USER_NOT_FOUND("사용자를 찾을 수 없습니다.", "[Error] : admin work assignment user not found", HttpStatus.BAD_REQUEST),
     ADMIN_WORK_ASSIGNMENT_DUPLICATED("이미 해당 시간에 배치된 사용자입니다.", "[Error] : duplicated admin work assignment", HttpStatus.CONFLICT),
     ADMIN_WORK_ASSIGNMENT_WORKPLACE_NOT_FOUND("조직의 근무지를 찾을 수 없습니다.", "[Error] : admin work assignment workplace not found", HttpStatus.NOT_FOUND),
+    ADMIN_WORK_SCHEDULE_NOT_FOUND("근로 시간표를 찾을 수 없습니다.", "[Error] : admin work schedule not found", HttpStatus.NOT_FOUND),
+    ADMIN_WORK_SCHEDULE_HAS_ATTENDANCE("출퇴근 기록이 있어 삭제할 수 없습니다.", "[Error] : admin work schedule has attendance", HttpStatus.CONFLICT),
     INVALID_CHANGE_REQUEST_IDS("요청 ID 목록이 올바르지 않습니다.", "[Error] : invalid change request ids", HttpStatus.BAD_REQUEST),
     INVALID_CHANGE_REQUEST_PROCESS_STATUS("올바르지 않은 처리 상태입니다.", "[Error] : invalid change request process status", HttpStatus.BAD_REQUEST),
     CHANGE_REQUEST_REJECT_REASON_REQUIRED("거절 사유를 입력해야 합니다.", "[Error] : change request reject reason required", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/UserErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/UserErrorCode.java
@@ -1,0 +1,41 @@
+package com.better.CommuteMate.global.exceptions.error;
+
+import org.springframework.http.HttpStatus;
+
+public enum UserErrorCode implements CustomErrorCode {
+    ADMIN_USER_SEARCH_KEYWORD_REQUIRED(
+            "검색어를 입력해주세요.",
+            "[Error] : admin user search keyword required",
+            HttpStatus.BAD_REQUEST
+    );
+
+    private final String message;
+    private final String logMessage;
+    private final HttpStatus status;
+
+    UserErrorCode(String message, String logMessage, HttpStatus status) {
+        this.message = message;
+        this.logMessage = logMessage;
+        this.status = status;
+    }
+
+    @Override
+    public String getLogMessage() {
+        return logMessage;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkAssignmentService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkAssignmentService.java
@@ -1,0 +1,146 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.entity.WorkScheduleSetting;
+import com.better.CommuteMate.domain.schedule.repository.WorkScheduleSettingRepository;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.domain.workplace.entity.Workplace;
+import com.better.CommuteMate.domain.workplace.repository.WorkplaceRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.ScheduleErrorCode;
+import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkAssignmentRequest;
+import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkAssignmentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminWorkAssignmentService {
+
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT);
+    private static final DateTimeFormatter TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("HH:mm").withResolverStyle(ResolverStyle.STRICT);
+    private static final List<CodeType> DUPLICATE_STATUSES =
+            List.of(CodeType.WS01, CodeType.WS02);
+
+    private final UserRepository userRepository;
+    private final WorkScheduleSettingRepository settingRepository;
+    private final WorkplaceRepository workplaceRepository;
+    private final WorkSchedulesRepository scheduleRepository;
+
+    @Transactional
+    public AdminWorkAssignmentResponse assign(
+            AdminWorkAssignmentRequest request,
+            Long organizationId,
+            Long adminId
+    ) {
+        ParsedAssignment parsed = parseAndValidate(request);
+        User user = findUser(request.userId(), organizationId);
+
+        WorkScheduleSetting setting = settingRepository.findForUpdate(
+                        String.valueOf(organizationId),
+                        parsed.date().getYear(),
+                        parsed.date().getMonthValue()
+                )
+                .orElseThrow(() -> CustomException.of(
+                        ScheduleErrorCode.ADMIN_SCHEDULE_SETTING_NOT_FOUND
+                ));
+        Workplace workplace = workplaceRepository
+                .findFirstByOrganizationId(String.valueOf(organizationId))
+                .orElseThrow(() -> CustomException.of(
+                        ScheduleErrorCode.ADMIN_WORK_ASSIGNMENT_WORKPLACE_NOT_FOUND
+                ));
+
+        if (scheduleRepository
+                .existsByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeIn(
+                        user.getUserId(),
+                        parsed.date(),
+                        parsed.startTime(),
+                        parsed.endTime(),
+                        DUPLICATE_STATUSES
+                )) {
+            throw CustomException.of(ScheduleErrorCode.ADMIN_WORK_ASSIGNMENT_DUPLICATED);
+        }
+
+        WorkSchedule schedule = scheduleRepository.saveAndFlush(WorkSchedule.builder()
+                .user(user)
+                .setting(setting)
+                .workplace(workplace)
+                .date(parsed.date())
+                .startTime(parsed.startTime())
+                .endTime(parsed.endTime())
+                .statusCode(CodeType.WS02)
+                .createdBy(String.valueOf(adminId))
+                .updatedBy(String.valueOf(adminId))
+                .build());
+
+        long currentCount = scheduleRepository
+                .countBySettingAndDateAndStartTimeAndEndTimeAndStatusCode(
+                        setting,
+                        parsed.date(),
+                        parsed.startTime(),
+                        parsed.endTime(),
+                        CodeType.WS02
+        );
+        return new AdminWorkAssignmentResponse(
+                schedule.getScheduleId(),
+                String.valueOf(user.getUserId()),
+                user.getName(),
+                parsed.date(),
+                parsed.startTime(),
+                parsed.endTime(),
+                currentCount,
+                setting.getMaxConcurrentWorkers()
+        );
+    }
+
+    private User findUser(String userIdValue, Long organizationId) {
+        try {
+            return userRepository
+                    .findByUserIdAndOrganizationId(Long.parseLong(userIdValue), organizationId)
+                    .orElseThrow(() -> CustomException.of(
+                            ScheduleErrorCode.ADMIN_WORK_ASSIGNMENT_USER_NOT_FOUND
+                    ));
+        } catch (NumberFormatException e) {
+            throw CustomException.of(ScheduleErrorCode.ADMIN_WORK_ASSIGNMENT_USER_NOT_FOUND);
+        }
+    }
+
+    private ParsedAssignment parseAndValidate(AdminWorkAssignmentRequest request) {
+        try {
+            LocalDate date = LocalDate.parse(request.date(), DATE_FORMATTER);
+            LocalTime startTime = LocalTime.parse(request.startTime(), TIME_FORMATTER);
+            LocalTime endTime = LocalTime.parse(request.endTime(), TIME_FORMATTER);
+            if (startTime.getMinute() % 30 != 0
+                    || !endTime.equals(startTime.plusMinutes(30))) {
+                throw invalidTime();
+            }
+            return new ParsedAssignment(date, startTime, endTime);
+        } catch (DateTimeParseException e) {
+            throw invalidTime();
+        }
+    }
+
+    private CustomException invalidTime() {
+        return CustomException.of(ScheduleErrorCode.INVALID_ADMIN_WORK_ASSIGNMENT_TIME);
+    }
+
+    private record ParsedAssignment(
+            LocalDate date,
+            LocalTime startTime,
+            LocalTime endTime
+    ) {
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkAssignmentService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkAssignmentService.java
@@ -74,17 +74,38 @@ public class AdminWorkAssignmentService {
             throw CustomException.of(ScheduleErrorCode.ADMIN_WORK_ASSIGNMENT_DUPLICATED);
         }
 
-        WorkSchedule schedule = scheduleRepository.saveAndFlush(WorkSchedule.builder()
-                .user(user)
-                .setting(setting)
-                .workplace(workplace)
-                .date(parsed.date())
-                .startTime(parsed.startTime())
-                .endTime(parsed.endTime())
-                .statusCode(CodeType.WS02)
-                .createdBy(String.valueOf(adminId))
-                .updatedBy(String.valueOf(adminId))
-                .build());
+        WorkSchedule schedule = scheduleRepository
+                .findFirstByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeOrderByUpdatedAtDesc(
+                        user.getUserId(),
+                        parsed.date(),
+                        parsed.startTime(),
+                        parsed.endTime(),
+                        CodeType.WS04
+                )
+                .map(cancelled -> {
+                    cancelled.updateSchedule(
+                            setting,
+                            workplace,
+                            parsed.date(),
+                            parsed.startTime(),
+                            parsed.endTime(),
+                            String.valueOf(adminId)
+                    );
+                    cancelled.updateStatus(CodeType.WS02, String.valueOf(adminId));
+                    return cancelled;
+                })
+                .orElseGet(() -> WorkSchedule.builder()
+                        .user(user)
+                        .setting(setting)
+                        .workplace(workplace)
+                        .date(parsed.date())
+                        .startTime(parsed.startTime())
+                        .endTime(parsed.endTime())
+                        .statusCode(CodeType.WS02)
+                        .createdBy(String.valueOf(adminId))
+                        .updatedBy(String.valueOf(adminId))
+                        .build());
+        schedule = scheduleRepository.saveAndFlush(schedule);
 
         long currentCount = scheduleRepository
                 .countBySettingAndDateAndStartTimeAndEndTimeAndStatusCode(

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleDeletionService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleDeletionService.java
@@ -1,0 +1,77 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.entity.WorkScheduleSetting;
+import com.better.CommuteMate.domain.schedule.repository.WorkScheduleSettingRepository;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.workattendance.repository.WorkAttendanceRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.ScheduleErrorCode;
+import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkScheduleDeleteResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminWorkScheduleDeletionService {
+
+    private static final List<CodeType> DELETABLE_STATUSES =
+            List.of(CodeType.WS01, CodeType.WS02);
+
+    private final WorkSchedulesRepository scheduleRepository;
+    private final WorkScheduleSettingRepository settingRepository;
+    private final WorkAttendanceRepository attendanceRepository;
+
+    @Transactional
+    public AdminWorkScheduleDeleteResponse delete(
+            String scheduleId,
+            Long organizationId,
+            Long adminId
+    ) {
+        WorkSchedule schedule = scheduleRepository
+                .findByScheduleIdAndUser_OrganizationIdAndStatusCodeIn(
+                        scheduleId, organizationId, DELETABLE_STATUSES
+                )
+                .orElseThrow(() -> CustomException.of(
+                        ScheduleErrorCode.ADMIN_WORK_SCHEDULE_NOT_FOUND
+                ));
+
+        WorkScheduleSetting setting = settingRepository.findForUpdate(
+                        String.valueOf(organizationId),
+                        schedule.getDate().getYear(),
+                        schedule.getDate().getMonthValue()
+                )
+                .orElseThrow(() -> CustomException.of(
+                        ScheduleErrorCode.ADMIN_SCHEDULE_SETTING_NOT_FOUND
+                ));
+
+        if (attendanceRepository.existsBySchedule_ScheduleId(scheduleId)) {
+            throw CustomException.of(ScheduleErrorCode.ADMIN_WORK_SCHEDULE_HAS_ATTENDANCE);
+        }
+
+        schedule.cancel(String.valueOf(adminId));
+        scheduleRepository.flush();
+
+        long currentCount = scheduleRepository
+                .countBySettingAndDateAndStartTimeAndEndTimeAndStatusCode(
+                        setting,
+                        schedule.getDate(),
+                        schedule.getStartTime(),
+                        schedule.getEndTime(),
+                        CodeType.WS02
+                );
+
+        return new AdminWorkScheduleDeleteResponse(
+                schedule.getScheduleId(),
+                schedule.getDate(),
+                schedule.getStartTime(),
+                schedule.getEndTime(),
+                currentCount,
+                setting.getMaxConcurrentWorkers()
+        );
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQuickSearchService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQuickSearchService.java
@@ -1,0 +1,160 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.ScheduleErrorCode;
+import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkScheduleQuickSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminWorkScheduleQuickSearchService {
+
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT);
+
+    private final UserRepository userRepository;
+    private final WorkSchedulesRepository scheduleRepository;
+
+    public AdminWorkScheduleQuickSearchResponse search(
+            String userIdValue,
+            String startDateValue,
+            String endDateValue,
+            Long organizationId
+    ) {
+        User user = findUser(userIdValue, organizationId);
+        DateRange range = parseRange(startDateValue, endDateValue);
+
+        List<WorkSchedule> schedules =
+                scheduleRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(
+                        user.getUserId(),
+                        range.startDate(),
+                        range.endDate(),
+                        List.of(CodeType.WS02)
+                );
+
+        Map<LocalDate, List<WorkSchedule>> schedulesByDate = new LinkedHashMap<>();
+        schedules.stream()
+                .sorted(Comparator.comparing(WorkSchedule::getDate)
+                        .thenComparing(WorkSchedule::getStartTime)
+                        .thenComparing(WorkSchedule::getEndTime))
+                .forEach(schedule -> schedulesByDate
+                        .computeIfAbsent(schedule.getDate(), ignored -> new ArrayList<>())
+                        .add(schedule));
+
+        List<AdminWorkScheduleQuickSearchResponse.Day> days = schedulesByDate.entrySet().stream()
+                .map(entry -> new AdminWorkScheduleQuickSearchResponse.Day(
+                        entry.getKey(),
+                        koreanDayOfWeek(entry.getKey().getDayOfWeek()),
+                        mergeSlots(entry.getValue())
+                ))
+                .toList();
+
+        return new AdminWorkScheduleQuickSearchResponse(
+                String.valueOf(user.getUserId()),
+                user.getName(),
+                days
+        );
+    }
+
+    private User findUser(String userIdValue, Long organizationId) {
+        try {
+            return userRepository
+                    .findByUserIdAndOrganizationId(Long.parseLong(userIdValue), organizationId)
+                    .orElseThrow(() -> CustomException.of(
+                            ScheduleErrorCode.ADMIN_WORK_SCHEDULE_USER_NOT_FOUND
+                    ));
+        } catch (NumberFormatException e) {
+            throw CustomException.of(ScheduleErrorCode.ADMIN_WORK_SCHEDULE_USER_NOT_FOUND);
+        }
+    }
+
+    private DateRange parseRange(String startDateValue, String endDateValue) {
+        if (startDateValue == null || startDateValue.isBlank()
+                || endDateValue == null || endDateValue.isBlank()) {
+            throw invalidRange();
+        }
+        try {
+            LocalDate startDate = LocalDate.parse(startDateValue, DATE_FORMATTER);
+            LocalDate endDate = LocalDate.parse(endDateValue, DATE_FORMATTER);
+            if (startDate.isAfter(endDate)) {
+                throw invalidRange();
+            }
+            return new DateRange(startDate, endDate);
+        } catch (DateTimeParseException e) {
+            throw invalidRange();
+        }
+    }
+
+    private List<AdminWorkScheduleQuickSearchResponse.Slot> mergeSlots(
+            List<WorkSchedule> schedules
+    ) {
+        List<AdminWorkScheduleQuickSearchResponse.Slot> merged = new ArrayList<>();
+        LocalTime currentStart = null;
+        LocalTime currentEnd = null;
+
+        for (WorkSchedule schedule : schedules) {
+            if (currentStart == null) {
+                currentStart = schedule.getStartTime();
+                currentEnd = schedule.getEndTime();
+                continue;
+            }
+            if (!schedule.getStartTime().isAfter(currentEnd)) {
+                if (schedule.getEndTime().isAfter(currentEnd)) {
+                    currentEnd = schedule.getEndTime();
+                }
+                continue;
+            }
+            merged.add(new AdminWorkScheduleQuickSearchResponse.Slot(
+                    currentStart, currentEnd
+            ));
+            currentStart = schedule.getStartTime();
+            currentEnd = schedule.getEndTime();
+        }
+
+        if (currentStart != null) {
+            merged.add(new AdminWorkScheduleQuickSearchResponse.Slot(
+                    currentStart, currentEnd
+            ));
+        }
+        return merged;
+    }
+
+    private String koreanDayOfWeek(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+    }
+
+    private CustomException invalidRange() {
+        return CustomException.of(ScheduleErrorCode.ADMIN_WORK_SCHEDULE_INVALID_RANGE);
+    }
+
+    private record DateRange(LocalDate startDate, LocalDate endDate) {
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminScheduleController.java
@@ -34,7 +34,35 @@ public class AdminScheduleController {
     @PutMapping("/work-application-settings/{year}/{month}")
     @Operation(
             summary = "월별 근로신청 설정 저장",
-            description = "설정을 생성 또는 수정하고 새 규칙에 맞지 않는 기존 신청을 취소합니다."
+            description = "설정을 생성 또는 수정하고 새 규칙에 맞지 않는 기존 신청을 취소합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "월별 근로신청 설정",
+                                    value = """
+                                            {
+                                              "applyStartDate": "2026-04-01",
+                                              "applyEndDate": "2026-04-10",
+                                              "unavailableDates": ["2026-04-19"],
+                                              "unavailableTimeRanges": [
+                                                {
+                                                  "start": "11:00",
+                                                  "end": "13:00"
+                                                }
+                                              ],
+                                              "maxConcurrentWorkers": 4,
+                                              "minWorkUnitMinutes": 120,
+                                              "weeklyMinMinutes": 300,
+                                              "weeklyMaxMinutes": 540,
+                                              "monthlyMinMinutes": 1200,
+                                              "monthlyMaxMinutes": 1620
+                                            }
+                                            """
+                            )
+                    )
+            )
     )
     @ApiResponses({
             @ApiResponse(

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
@@ -3,10 +3,12 @@ package com.better.CommuteMate.schedule.controller.admin;
 import com.better.CommuteMate.auth.application.CustomUserDetails;
 import com.better.CommuteMate.global.controller.dtos.Response;
 import com.better.CommuteMate.schedule.application.AdminWorkAssignmentService;
+import com.better.CommuteMate.schedule.application.AdminWorkScheduleDeletionService;
 import com.better.CommuteMate.schedule.application.AdminWorkScheduleQueryService;
 import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkAssignmentRequest;
 import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkAssignmentResponse;
 import com.better.CommuteMate.schedule.controller.admin.dtos.AdminScheduleRangeResponse;
+import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkScheduleDeleteResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -20,6 +22,8 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,6 +38,7 @@ public class AdminWorkScheduleController {
 
     private final AdminWorkScheduleQueryService queryService;
     private final AdminWorkAssignmentService assignmentService;
+    private final AdminWorkScheduleDeletionService deletionService;
 
     @PostMapping
     @Operation(
@@ -178,6 +183,105 @@ public class AdminWorkScheduleController {
         );
         return ResponseEntity.ok(Response.of(
                 true, "근로 시간표가 추가되었습니다.", details
+        ));
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    @Operation(
+            summary = "근로 시간표 삭제",
+            description = """
+                    관리자가 소속 조직의 근로 시간표를 삭제합니다.
+                    실제 행은 삭제하지 않고 상태를 WS04(취소)로 변경합니다.
+                    출퇴근 기록이 있는 스케줄은 삭제할 수 없습니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "근로 시간표 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "삭제 성공",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "message": "근로 시간표가 삭제되었습니다.",
+                                              "details": {
+                                                "scheduleId": "e5f6a7b8-1f2c-4d3e-9a5b-6c7d8e9f0123",
+                                                "date": "2026-09-08",
+                                                "startTime": "09:00",
+                                                "endTime": "09:30",
+                                                "currentCount": 2,
+                                                "maxConcurrentWorkers": 4
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "스케줄 또는 해당 월의 설정을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "근로 시간표 없음",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "근로 시간표를 찾을 수 없습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "월별 스케줄 설정 없음",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "해당 월의 스케줄 설정을 찾을 수 없습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 출퇴근 기록이 있는 스케줄",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "출퇴근 기록 존재",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "message": "출퇴근 기록이 있어 삭제할 수 없습니다.",
+                                              "details": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> deleteSchedule(
+            @Parameter(description = "삭제할 스케줄 ID", example = "e5f6a7b8-1f2c-4d3e-9a5b-6c7d8e9f0123", required = true)
+            @PathVariable String scheduleId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        AdminWorkScheduleDeleteResponse details = deletionService.delete(
+                scheduleId,
+                userDetails.getUser().getOrganizationId(),
+                userDetails.getUser().getUserId()
+        );
+        return ResponseEntity.ok(Response.of(
+                true, "근로 시간표가 삭제되었습니다.", details
         ));
     }
 

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
@@ -4,11 +4,13 @@ import com.better.CommuteMate.auth.application.CustomUserDetails;
 import com.better.CommuteMate.global.controller.dtos.Response;
 import com.better.CommuteMate.schedule.application.AdminWorkAssignmentService;
 import com.better.CommuteMate.schedule.application.AdminWorkScheduleDeletionService;
+import com.better.CommuteMate.schedule.application.AdminWorkScheduleQuickSearchService;
 import com.better.CommuteMate.schedule.application.AdminWorkScheduleQueryService;
 import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkAssignmentRequest;
 import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkAssignmentResponse;
 import com.better.CommuteMate.schedule.controller.admin.dtos.AdminScheduleRangeResponse;
 import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkScheduleDeleteResponse;
+import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkScheduleQuickSearchResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -39,6 +41,7 @@ public class AdminWorkScheduleController {
     private final AdminWorkScheduleQueryService queryService;
     private final AdminWorkAssignmentService assignmentService;
     private final AdminWorkScheduleDeletionService deletionService;
+    private final AdminWorkScheduleQuickSearchService quickSearchService;
 
     @PostMapping
     @Operation(
@@ -282,6 +285,105 @@ public class AdminWorkScheduleController {
         );
         return ResponseEntity.ok(Response.of(
                 true, "근로 시간표가 삭제되었습니다.", details
+        ));
+    }
+
+    @GetMapping("/quick-search")
+    @Operation(
+            summary = "사용자 근로 시간표 빠른 조회",
+            description = """
+                    같은 조직 사용자의 승인(WS02) 근로 시간표를 기간 내에서 조회합니다.
+                    연속되거나 겹치는 슬롯은 하나의 구간으로 병합하며,
+                    배치가 없는 날짜는 응답에서 제외합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "근로 시간표 빠른 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "조회 성공",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "message": "요청에 성공하였습니다.",
+                                              "details": {
+                                                "userId": "2",
+                                                "userName": "박영희",
+                                                "days": [
+                                                  {
+                                                    "date": "2026-09-10",
+                                                    "dayOfWeek": "목",
+                                                    "slots": [
+                                                      {"start": "09:30", "end": "11:30"}
+                                                    ]
+                                                  },
+                                                  {
+                                                    "date": "2026-09-11",
+                                                    "dayOfWeek": "금",
+                                                    "slots": [
+                                                      {"start": "16:30", "end": "18:30"}
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "사용자를 찾을 수 없거나 조회 기간이 올바르지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "사용자 없음 또는 다른 조직 소속",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "사용자를 찾을 수 없습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "조회 기간 오류",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "조회 기간이 올바르지 않습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> quickSearch(
+            @Parameter(description = "조회할 사용자 ID", example = "2", required = true)
+            @RequestParam(required = false) String userId,
+            @Parameter(description = "조회 시작일 (YYYY-MM-DD)", example = "2026-09-07", required = true)
+            @RequestParam(required = false) String startDate,
+            @Parameter(description = "조회 종료일 (YYYY-MM-DD)", example = "2026-09-11", required = true)
+            @RequestParam(required = false) String endDate,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        AdminWorkScheduleQuickSearchResponse details = quickSearchService.search(
+                userId,
+                startDate,
+                endDate,
+                userDetails.getUser().getOrganizationId()
+        );
+        return ResponseEntity.ok(Response.of(
+                true, "요청에 성공하였습니다.", details
         ));
     }
 

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
@@ -2,7 +2,10 @@ package com.better.CommuteMate.schedule.controller.admin;
 
 import com.better.CommuteMate.auth.application.CustomUserDetails;
 import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.schedule.application.AdminWorkAssignmentService;
 import com.better.CommuteMate.schedule.application.AdminWorkScheduleQueryService;
+import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkAssignmentRequest;
+import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkAssignmentResponse;
 import com.better.CommuteMate.schedule.controller.admin.dtos.AdminScheduleRangeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,9 +16,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +33,153 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminWorkScheduleController {
 
     private final AdminWorkScheduleQueryService queryService;
+    private final AdminWorkAssignmentService assignmentService;
+
+    @PostMapping
+    @Operation(
+            summary = "근로 시간표 직접 배치",
+            description = """
+                    관리자가 소속 조직의 사용자를 30분 근로 슬롯에 직접 배치합니다.
+                    생성된 일정은 승인 절차 없이 WS02(승인) 상태가 되며,
+                    현재 인원이 최대 동시 근무 인원을 초과하더라도 배치할 수 있습니다.
+                    """,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "근로 시간표 배치 요청",
+                                    value = """
+                                            {
+                                              "userId": "1",
+                                              "date": "2026-09-08",
+                                              "startTime": "09:00",
+                                              "endTime": "09:30"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "근로 시간표 추가 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "배치 성공",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "message": "근로 시간표가 추가되었습니다.",
+                                              "details": {
+                                                "scheduleId": "9f36a98d-1377-4f44-86bb-f87ff47e39ac",
+                                                "userId": "1",
+                                                "userName": "홍길동",
+                                                "date": "2026-09-08",
+                                                "startTime": "09:00",
+                                                "endTime": "09:30",
+                                                "currentCount": 3,
+                                                "maxConcurrentWorkers": 4
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "시간 형식 오류 또는 사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "30분 단위가 아닌 시간",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "근로 시간은 30분 단위로만 지정할 수 있습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "사용자 없음 또는 다른 조직 소속",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "사용자를 찾을 수 없습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "사용자가 해당 슬롯에 이미 배치됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "중복 배치",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "message": "이미 해당 시간에 배치된 사용자입니다.",
+                                              "details": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 월의 스케줄 설정 또는 조직의 근무지를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "월별 스케줄 설정 없음",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "해당 월의 스케줄 설정을 찾을 수 없습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "조직 근무지 없음",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "조직의 근무지를 찾을 수 없습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> assignSchedule(
+            @Valid @RequestBody AdminWorkAssignmentRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long organizationId = userDetails.getUser().getOrganizationId();
+        Long adminId = userDetails.getUser().getUserId();
+        AdminWorkAssignmentResponse details = assignmentService.assign(
+                request, organizationId, adminId
+        );
+        return ResponseEntity.ok(Response.of(
+                true, "근로 시간표가 추가되었습니다.", details
+        ));
+    }
 
     @GetMapping
     @Operation(summary = "근로시간표 조회", description = "같은 달 안의 근로시간표를 30분 슬롯 단위로 조회합니다.")

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminWorkAssignmentRequest.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminWorkAssignmentRequest.java
@@ -1,0 +1,23 @@
+package com.better.CommuteMate.schedule.controller.admin.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminWorkAssignmentRequest(
+        @Schema(description = "배치할 사용자 ID", example = "1")
+        @NotBlank(message = "요청 값이 올바르지 않습니다.")
+        String userId,
+
+        @Schema(description = "근무 날짜 (YYYY-MM-DD)", example = "2026-09-08")
+        @NotBlank(message = "요청 값이 올바르지 않습니다.")
+        String date,
+
+        @Schema(description = "시작 시간 (HH:mm, 정각 또는 30분)", example = "09:00")
+        @NotBlank(message = "요청 값이 올바르지 않습니다.")
+        String startTime,
+
+        @Schema(description = "종료 시간 (HH:mm, 시작 시간 + 30분)", example = "09:30")
+        @NotBlank(message = "요청 값이 올바르지 않습니다.")
+        String endTime
+) {
+}

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminWorkAssignmentResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminWorkAssignmentResponse.java
@@ -1,0 +1,48 @@
+package com.better.CommuteMate.schedule.controller.admin.dtos;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+public class AdminWorkAssignmentResponse extends ResponseDetail {
+
+    private final String scheduleId;
+    private final String userId;
+    private final String userName;
+    private final LocalDate date;
+    private final LocalTime startTime;
+    private final LocalTime endTime;
+    private final long currentCount;
+    private final int maxConcurrentWorkers;
+
+    public AdminWorkAssignmentResponse(
+            String scheduleId,
+            String userId,
+            String userName,
+            LocalDate date,
+            LocalTime startTime,
+            LocalTime endTime,
+            long currentCount,
+            int maxConcurrentWorkers
+    ) {
+        this.scheduleId = scheduleId;
+        this.userId = userId;
+        this.userName = userName;
+        this.date = date;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.currentCount = currentCount;
+        this.maxConcurrentWorkers = maxConcurrentWorkers;
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminWorkScheduleDeleteResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminWorkScheduleDeleteResponse.java
@@ -10,11 +10,9 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
-public class AdminWorkAssignmentResponse extends ResponseDetail {
+public class AdminWorkScheduleDeleteResponse extends ResponseDetail {
 
     private final String scheduleId;
-    private final String userId;
-    private final String userName;
     private final LocalDate date;
     @JsonFormat(pattern = "HH:mm")
     private final LocalTime startTime;
@@ -23,10 +21,8 @@ public class AdminWorkAssignmentResponse extends ResponseDetail {
     private final long currentCount;
     private final int maxConcurrentWorkers;
 
-    public AdminWorkAssignmentResponse(
+    public AdminWorkScheduleDeleteResponse(
             String scheduleId,
-            String userId,
-            String userName,
             LocalDate date,
             LocalTime startTime,
             LocalTime endTime,
@@ -34,8 +30,6 @@ public class AdminWorkAssignmentResponse extends ResponseDetail {
             int maxConcurrentWorkers
     ) {
         this.scheduleId = scheduleId;
-        this.userId = userId;
-        this.userName = userName;
         this.date = date;
         this.startTime = startTime;
         this.endTime = endTime;

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminWorkScheduleQuickSearchResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminWorkScheduleQuickSearchResponse.java
@@ -1,0 +1,46 @@
+package com.better.CommuteMate.schedule.controller.admin.dtos;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+public class AdminWorkScheduleQuickSearchResponse extends ResponseDetail {
+
+    public final String userId;
+    public final String userName;
+    public final List<Day> days;
+
+    public AdminWorkScheduleQuickSearchResponse(
+            String userId,
+            String userName,
+            List<Day> days
+    ) {
+        this.userId = userId;
+        this.userName = userName;
+        this.days = days;
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+
+    public record Day(
+            LocalDate date,
+            String dayOfWeek,
+            List<Slot> slots
+    ) {
+    }
+
+    public record Slot(
+            @JsonFormat(pattern = "HH:mm") LocalTime start,
+            @JsonFormat(pattern = "HH:mm") LocalTime end
+    ) {
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/SaveScheduleSettingRequest.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/SaveScheduleSettingRequest.java
@@ -1,6 +1,7 @@
 package com.better.CommuteMate.schedule.controller.admin.dtos;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -10,15 +11,36 @@ import java.time.LocalTime;
 import java.util.List;
 
 public record SaveScheduleSettingRequest(
+        @Schema(type = "string", format = "date", example = "2026-04-01")
+        @JsonFormat(pattern = "yyyy-MM-dd")
         @NotNull(message = "요청 값이 올바르지 않습니다.") LocalDate applyStartDate,
+
+        @Schema(type = "string", format = "date", example = "2026-04-10")
+        @JsonFormat(pattern = "yyyy-MM-dd")
         @NotNull(message = "요청 값이 올바르지 않습니다.") LocalDate applyEndDate,
+
+        @Schema(example = "[\"2026-04-19\"]")
         List<@NotNull(message = "요청 값이 올바르지 않습니다.") LocalDate> unavailableDates,
+
+        @Schema(example = "[{\"start\":\"11:00\",\"end\":\"13:00\"}]")
         List<@NotNull(message = "요청 값이 올바르지 않습니다.") @Valid UnavailableTimeRange> unavailableTimeRanges,
+
+        @Schema(example = "4")
         @NotNull(message = "요청 값이 올바르지 않습니다.") @Min(value = 1, message = "요청 값이 올바르지 않습니다.") Integer maxConcurrentWorkers,
+
+        @Schema(example = "120")
         @NotNull(message = "요청 값이 올바르지 않습니다.") @Min(value = 1, message = "요청 값이 올바르지 않습니다.") Integer minWorkUnitMinutes,
+
+        @Schema(example = "300")
         @NotNull(message = "요청 값이 올바르지 않습니다.") @Min(value = 0, message = "요청 값이 올바르지 않습니다.") Integer weeklyMinMinutes,
+
+        @Schema(example = "540")
         @NotNull(message = "요청 값이 올바르지 않습니다.") @Min(value = 0, message = "요청 값이 올바르지 않습니다.") Integer weeklyMaxMinutes,
+
+        @Schema(example = "1200")
         @NotNull(message = "요청 값이 올바르지 않습니다.") @Min(value = 0, message = "요청 값이 올바르지 않습니다.") Integer monthlyMinMinutes,
+
+        @Schema(example = "1620")
         @NotNull(message = "요청 값이 올바르지 않습니다.") @Min(value = 0, message = "요청 값이 올바르지 않습니다.") Integer monthlyMaxMinutes
 ) {
     public List<LocalDate> unavailableDatesOrEmpty() {
@@ -30,8 +52,11 @@ public record SaveScheduleSettingRequest(
     }
 
     public record UnavailableTimeRange(
+            @Schema(type = "string", format = "time", example = "11:00")
             @NotNull(message = "요청 값이 올바르지 않습니다.")
             @JsonFormat(pattern = "HH:mm") LocalTime start,
+
+            @Schema(type = "string", format = "time", example = "13:00")
             @NotNull(message = "요청 값이 올바르지 않습니다.")
             @JsonFormat(pattern = "HH:mm") LocalTime end
     ) {

--- a/src/main/java/com/better/CommuteMate/user/application/AdminUserSearchService.java
+++ b/src/main/java/com/better/CommuteMate/user/application/AdminUserSearchService.java
@@ -1,0 +1,35 @@
+package com.better.CommuteMate.user.application;
+
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.UserErrorCode;
+import com.better.CommuteMate.user.controller.dto.AdminUserSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserSearchService {
+
+    private final UserRepository userRepository;
+
+    public AdminUserSearchResponse search(Long organizationId, String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            throw CustomException.of(UserErrorCode.ADMIN_USER_SEARCH_KEYWORD_REQUIRED);
+        }
+
+        List<User> users = userRepository
+                .findAllByOrganizationIdAndRoleCodeAndNameContainingIgnoreCaseOrderByNameAscUserIdAsc(
+                        organizationId,
+                        CodeType.RL01,
+                        keyword.trim()
+                );
+        return AdminUserSearchResponse.from(users);
+    }
+}

--- a/src/main/java/com/better/CommuteMate/user/controller/AdminUserController.java
+++ b/src/main/java/com/better/CommuteMate/user/controller/AdminUserController.java
@@ -1,0 +1,98 @@
+package com.better.CommuteMate.user.controller;
+
+import com.better.CommuteMate.auth.application.CustomUserDetails;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.user.application.AdminUserSearchService;
+import com.better.CommuteMate.user.controller.dto.AdminUserSearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "관리자 사용자 관리", description = "관리자용 조직 사용자 조회 API")
+@RestController
+@RequestMapping("/api/v1/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final AdminUserSearchService searchService;
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "학생 사용자 검색",
+            description = "로그인한 관리자와 같은 조직에 소속된 학생을 이름 부분 일치로 검색합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "검색 성공",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "message": "요청에 성공하였습니다.",
+                                              "details": {
+                                                "users": [
+                                                  {"userId": "2", "userName": "박영희"},
+                                                  {"userId": "3", "userName": "박지민"},
+                                                  {"userId": "4", "userName": "박보검"}
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "검색어 누락 또는 빈 문자열",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "검색어 누락",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "message": "검색어를 입력해주세요.",
+                                              "details": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> searchUsers(
+            @Parameter(
+                    description = "학생 이름 검색어(최소 1자, 부분 일치)",
+                    example = "박",
+                    required = true
+            )
+            @RequestParam(required = false) String keyword,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        AdminUserSearchResponse details = searchService.search(
+                userDetails.getUser().getOrganizationId(),
+                keyword
+        );
+        return ResponseEntity.ok(Response.of(
+                true, "요청에 성공하였습니다.", details
+        ));
+    }
+}

--- a/src/main/java/com/better/CommuteMate/user/controller/dto/AdminUserSearchResponse.java
+++ b/src/main/java/com/better/CommuteMate/user/controller/dto/AdminUserSearchResponse.java
@@ -1,0 +1,35 @@
+package com.better.CommuteMate.user.controller.dto;
+
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AdminUserSearchResponse extends ResponseDetail {
+
+    public final List<UserSummary> users;
+
+    public AdminUserSearchResponse(List<UserSummary> users) {
+        this.users = users;
+    }
+
+    public static AdminUserSearchResponse from(List<User> users) {
+        return new AdminUserSearchResponse(users.stream()
+                .map(user -> new UserSummary(
+                        String.valueOf(user.getUserId()),
+                        user.getName()
+                ))
+                .toList());
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+
+    public record UserSummary(String userId, String userName) {
+    }
+}

--- a/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkAssignmentServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkAssignmentServiceTest.java
@@ -1,0 +1,178 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.entity.WorkScheduleSetting;
+import com.better.CommuteMate.domain.schedule.repository.WorkScheduleSettingRepository;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.domain.workplace.entity.Workplace;
+import com.better.CommuteMate.domain.workplace.repository.WorkplaceRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkAssignmentRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminWorkAssignmentServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock WorkScheduleSettingRepository settingRepository;
+    @Mock WorkplaceRepository workplaceRepository;
+    @Mock WorkSchedulesRepository scheduleRepository;
+
+    AdminWorkAssignmentService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminWorkAssignmentService(
+                userRepository, settingRepository, workplaceRepository, scheduleRepository
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 직접 배치 - 정원을 초과해도 WS02로 생성하고 추가 후 인원을 반환한다")
+    void assignsApprovedScheduleEvenWhenCapacityIsExceeded() {
+        LocalDate date = LocalDate.of(2026, 9, 8);
+        LocalTime start = LocalTime.of(9, 0);
+        LocalTime end = LocalTime.of(9, 30);
+        User user = User.builder()
+                .userId(1L)
+                .organizationId(10L)
+                .name("김송은")
+                .build();
+        WorkScheduleSetting setting = WorkScheduleSetting.builder()
+                .organizationId("10")
+                .year(2026)
+                .month(9)
+                .maxConcurrentWorkers(4)
+                .build();
+        Workplace workplace = Workplace.builder().build();
+
+        when(userRepository.findByUserIdAndOrganizationId(1L, 10L))
+                .thenReturn(Optional.of(user));
+        when(settingRepository.findForUpdate("10", 2026, 9))
+                .thenReturn(Optional.of(setting));
+        when(workplaceRepository.findFirstByOrganizationId("10"))
+                .thenReturn(Optional.of(workplace));
+        when(scheduleRepository
+                .existsByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeIn(
+                        1L, date, start, end, List.of(CodeType.WS01, CodeType.WS02)
+                ))
+                .thenReturn(false);
+        when(scheduleRepository.saveAndFlush(any(WorkSchedule.class)))
+                .thenAnswer(invocation -> {
+                    WorkSchedule schedule = invocation.getArgument(0);
+                    return WorkSchedule.builder()
+                            .scheduleId("ssid")
+                            .user(schedule.getUser())
+                            .setting(schedule.getSetting())
+                            .workplace(schedule.getWorkplace())
+                            .date(schedule.getDate())
+                            .startTime(schedule.getStartTime())
+                            .endTime(schedule.getEndTime())
+                            .statusCode(schedule.getStatusCode())
+                            .build();
+                });
+        when(scheduleRepository.countBySettingAndDateAndStartTimeAndEndTimeAndStatusCode(
+                setting, date, start, end, CodeType.WS02
+        )).thenReturn(5L);
+
+        var response = service.assign(request("09:00", "09:30"), 10L, 99L);
+
+        assertThat(response.getScheduleId()).isEqualTo("ssid");
+        assertThat(response.getUserName()).isEqualTo("김송은");
+        assertThat(response.getCurrentCount()).isEqualTo(5);
+        assertThat(response.getMaxConcurrentWorkers()).isEqualTo(4);
+        verify(scheduleRepository).saveAndFlush(any(WorkSchedule.class));
+    }
+
+    @Test
+    @DisplayName("관리자 직접 배치 - 30분 슬롯이 아니면 400 오류를 반환한다")
+    void rejectsInvalidThirtyMinuteSlot() {
+        assertThatThrownBy(() -> service.assign(request("09:10", "09:40"), 10L, 99L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("근로 시간은 30분 단위로만 지정할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("관리자 직접 배치 - 다른 조직 사용자면 사용자를 찾을 수 없음 오류를 반환한다")
+    void hidesUserFromOtherOrganization() {
+        when(userRepository.findByUserIdAndOrganizationId(1L, 10L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.assign(request("09:00", "09:30"), 10L, 99L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("관리자 직접 배치 - 활성 일정이 같은 슬롯에 있으면 중복 오류를 반환한다")
+    void rejectsDuplicateAssignment() {
+        LocalDate date = LocalDate.of(2026, 9, 8);
+        LocalTime start = LocalTime.of(9, 0);
+        LocalTime end = LocalTime.of(9, 30);
+        User user = User.builder().userId(1L).organizationId(10L).build();
+        WorkScheduleSetting setting = WorkScheduleSetting.builder()
+                .maxConcurrentWorkers(4)
+                .build();
+
+        when(userRepository.findByUserIdAndOrganizationId(1L, 10L))
+                .thenReturn(Optional.of(user));
+        when(settingRepository.findForUpdate("10", 2026, 9))
+                .thenReturn(Optional.of(setting));
+        when(workplaceRepository.findFirstByOrganizationId("10"))
+                .thenReturn(Optional.of(Workplace.builder().build()));
+        when(scheduleRepository
+                .existsByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeIn(
+                        1L, date, start, end, List.of(CodeType.WS01, CodeType.WS02)
+                ))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> service.assign(request("09:00", "09:30"), 10L, 99L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("이미 해당 시간에 배치된 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("관리자 직접 배치 - 조직의 근무지가 없으면 전용 오류를 반환한다")
+    void rejectsAssignmentWhenWorkplaceDoesNotExist() {
+        User user = User.builder().userId(1L).organizationId(10L).build();
+        WorkScheduleSetting setting = WorkScheduleSetting.builder()
+                .maxConcurrentWorkers(4)
+                .build();
+
+        when(userRepository.findByUserIdAndOrganizationId(1L, 10L))
+                .thenReturn(Optional.of(user));
+        when(settingRepository.findForUpdate("10", 2026, 9))
+                .thenReturn(Optional.of(setting));
+        when(workplaceRepository.findFirstByOrganizationId("10"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.assign(request("09:00", "09:30"), 10L, 99L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("조직의 근무지를 찾을 수 없습니다.");
+    }
+
+    private AdminWorkAssignmentRequest request(String startTime, String endTime) {
+        return new AdminWorkAssignmentRequest(
+                "1", "2026-09-08", startTime, endTime
+        );
+    }
+}

--- a/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkAssignmentServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkAssignmentServiceTest.java
@@ -170,6 +170,64 @@ class AdminWorkAssignmentServiceTest {
                 .hasMessage("조직의 근무지를 찾을 수 없습니다.");
     }
 
+    @Test
+    @DisplayName("관리자 직접 배치 - 취소된 동일 슬롯이 있으면 기존 스케줄을 WS02로 복구한다")
+    void restoresCancelledScheduleInsteadOfCreatingAnotherRow() {
+        LocalDate date = LocalDate.of(2026, 9, 8);
+        LocalTime start = LocalTime.of(9, 0);
+        LocalTime end = LocalTime.of(9, 30);
+        User user = User.builder()
+                .userId(1L)
+                .organizationId(10L)
+                .name("김송은")
+                .build();
+        WorkScheduleSetting setting = WorkScheduleSetting.builder()
+                .organizationId("10")
+                .year(2026)
+                .month(9)
+                .maxConcurrentWorkers(4)
+                .build();
+        Workplace workplace = Workplace.builder().build();
+        WorkSchedule cancelled = WorkSchedule.builder()
+                .scheduleId("cancelled-id")
+                .user(user)
+                .setting(setting)
+                .workplace(workplace)
+                .date(date)
+                .startTime(start)
+                .endTime(end)
+                .statusCode(CodeType.WS04)
+                .build();
+
+        when(userRepository.findByUserIdAndOrganizationId(1L, 10L))
+                .thenReturn(Optional.of(user));
+        when(settingRepository.findForUpdate("10", 2026, 9))
+                .thenReturn(Optional.of(setting));
+        when(workplaceRepository.findFirstByOrganizationId("10"))
+                .thenReturn(Optional.of(workplace));
+        when(scheduleRepository
+                .existsByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeIn(
+                        1L, date, start, end, List.of(CodeType.WS01, CodeType.WS02)
+                ))
+                .thenReturn(false);
+        when(scheduleRepository
+                .findFirstByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeOrderByUpdatedAtDesc(
+                        1L, date, start, end, CodeType.WS04
+                ))
+                .thenReturn(Optional.of(cancelled));
+        when(scheduleRepository.saveAndFlush(cancelled)).thenReturn(cancelled);
+        when(scheduleRepository.countBySettingAndDateAndStartTimeAndEndTimeAndStatusCode(
+                setting, date, start, end, CodeType.WS02
+        )).thenReturn(1L);
+
+        var response = service.assign(request("09:00", "09:30"), 10L, 99L);
+
+        assertThat(response.getScheduleId()).isEqualTo("cancelled-id");
+        assertThat(cancelled.getStatusCode()).isEqualTo(CodeType.WS02);
+        assertThat(cancelled.getUpdatedBy()).isEqualTo("99");
+        verify(scheduleRepository).saveAndFlush(cancelled);
+    }
+
     private AdminWorkAssignmentRequest request(String startTime, String endTime) {
         return new AdminWorkAssignmentRequest(
                 "1", "2026-09-08", startTime, endTime

--- a/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleDeletionServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleDeletionServiceTest.java
@@ -1,0 +1,130 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.entity.WorkScheduleSetting;
+import com.better.CommuteMate.domain.schedule.repository.WorkScheduleSettingRepository;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.workattendance.repository.WorkAttendanceRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminWorkScheduleDeletionServiceTest {
+
+    @Mock WorkSchedulesRepository scheduleRepository;
+    @Mock WorkScheduleSettingRepository settingRepository;
+    @Mock WorkAttendanceRepository attendanceRepository;
+
+    AdminWorkScheduleDeletionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminWorkScheduleDeletionService(
+                scheduleRepository, settingRepository, attendanceRepository
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 근로 시간표 삭제 - WS04로 변경하고 삭제 후 잔여 인원을 반환한다")
+    void softDeletesScheduleAndReturnsRemainingCount() {
+        WorkScheduleSetting setting = setting();
+        WorkSchedule schedule = schedule(setting);
+
+        when(scheduleRepository.findByScheduleIdAndUser_OrganizationIdAndStatusCodeIn(
+                "schedule-id", 10L, List.of(CodeType.WS01, CodeType.WS02)
+        )).thenReturn(Optional.of(schedule));
+        when(settingRepository.findForUpdate("10", 2026, 9))
+                .thenReturn(Optional.of(setting));
+        when(attendanceRepository.existsBySchedule_ScheduleId("schedule-id"))
+                .thenReturn(false);
+        when(scheduleRepository.countBySettingAndDateAndStartTimeAndEndTimeAndStatusCode(
+                setting,
+                LocalDate.of(2026, 9, 8),
+                LocalTime.of(9, 0),
+                LocalTime.of(9, 30),
+                CodeType.WS02
+        )).thenReturn(2L);
+
+        var response = service.delete("schedule-id", 10L, 99L);
+
+        assertThat(schedule.getStatusCode()).isEqualTo(CodeType.WS04);
+        assertThat(schedule.getUpdatedBy()).isEqualTo("99");
+        assertThat(response.getScheduleId()).isEqualTo("schedule-id");
+        assertThat(response.getCurrentCount()).isEqualTo(2);
+        assertThat(response.getMaxConcurrentWorkers()).isEqualTo(4);
+        verify(scheduleRepository).flush();
+    }
+
+    @Test
+    @DisplayName("관리자 근로 시간표 삭제 - 다른 조직, 취소 또는 없는 스케줄은 찾을 수 없음 처리한다")
+    void rejectsUnknownSchedule() {
+        when(scheduleRepository.findByScheduleIdAndUser_OrganizationIdAndStatusCodeIn(
+                "unknown", 10L, List.of(CodeType.WS01, CodeType.WS02)
+        )).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.delete("unknown", 10L, 99L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("근로 시간표를 찾을 수 없습니다.");
+
+        verify(attendanceRepository, never()).existsBySchedule_ScheduleId("unknown");
+    }
+
+    @Test
+    @DisplayName("관리자 근로 시간표 삭제 - 출퇴근 기록이 있으면 삭제하지 않는다")
+    void rejectsScheduleWithAttendance() {
+        WorkScheduleSetting setting = setting();
+        WorkSchedule schedule = schedule(setting);
+
+        when(scheduleRepository.findByScheduleIdAndUser_OrganizationIdAndStatusCodeIn(
+                "schedule-id", 10L, List.of(CodeType.WS01, CodeType.WS02)
+        )).thenReturn(Optional.of(schedule));
+        when(settingRepository.findForUpdate("10", 2026, 9))
+                .thenReturn(Optional.of(setting));
+        when(attendanceRepository.existsBySchedule_ScheduleId("schedule-id"))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> service.delete("schedule-id", 10L, 99L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("출퇴근 기록이 있어 삭제할 수 없습니다.");
+
+        assertThat(schedule.getStatusCode()).isEqualTo(CodeType.WS02);
+        verify(scheduleRepository, never()).flush();
+    }
+
+    private WorkScheduleSetting setting() {
+        return WorkScheduleSetting.builder()
+                .organizationId("10")
+                .year(2026)
+                .month(9)
+                .maxConcurrentWorkers(4)
+                .build();
+    }
+
+    private WorkSchedule schedule(WorkScheduleSetting setting) {
+        return WorkSchedule.builder()
+                .scheduleId("schedule-id")
+                .setting(setting)
+                .date(LocalDate.of(2026, 9, 8))
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(9, 30))
+                .statusCode(CodeType.WS02)
+                .build();
+    }
+}

--- a/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQuickSearchServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQuickSearchServiceTest.java
@@ -1,0 +1,149 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminWorkScheduleQuickSearchServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock WorkSchedulesRepository scheduleRepository;
+
+    AdminWorkScheduleQuickSearchService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminWorkScheduleQuickSearchService(
+                userRepository, scheduleRepository
+        );
+    }
+
+    @Test
+    @DisplayName("빠른 조회 - 연속 슬롯은 병합하고 끊긴 슬롯은 분리한다")
+    void mergesContinuousSlotsAndSeparatesGaps() {
+        User user = User.builder().userId(2L).name("박영희").build();
+        LocalDate startDate = LocalDate.of(2026, 9, 7);
+        LocalDate endDate = LocalDate.of(2026, 9, 11);
+        LocalDate thursday = LocalDate.of(2026, 9, 10);
+        LocalDate friday = LocalDate.of(2026, 9, 11);
+
+        when(userRepository.findByUserIdAndOrganizationId(2L, 10L))
+                .thenReturn(Optional.of(user));
+        when(scheduleRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(
+                2L, startDate, endDate, List.of(CodeType.WS02)
+        )).thenReturn(List.of(
+                schedule(thursday, 10, 0, 10, 30),
+                schedule(friday, 16, 30, 18, 30),
+                schedule(thursday, 9, 30, 10, 0),
+                schedule(thursday, 11, 0, 11, 30)
+        ));
+
+        var response = service.search(
+                "2", "2026-09-07", "2026-09-11", 10L
+        );
+
+        assertThat(response.userId).isEqualTo("2");
+        assertThat(response.userName).isEqualTo("박영희");
+        assertThat(response.days).hasSize(2);
+        assertThat(response.days.get(0).date()).isEqualTo(thursday);
+        assertThat(response.days.get(0).dayOfWeek()).isEqualTo("목");
+        assertThat(response.days.get(0).slots()).containsExactly(
+                new com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkScheduleQuickSearchResponse.Slot(
+                        LocalTime.of(9, 30), LocalTime.of(10, 30)
+                ),
+                new com.better.CommuteMate.schedule.controller.admin.dtos.AdminWorkScheduleQuickSearchResponse.Slot(
+                        LocalTime.of(11, 0), LocalTime.of(11, 30)
+                )
+        );
+        assertThat(response.days.get(1).dayOfWeek()).isEqualTo("금");
+        verify(scheduleRepository).findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(
+                2L, startDate, endDate, List.of(CodeType.WS02)
+        );
+    }
+
+    @Test
+    @DisplayName("빠른 조회 - 배치가 없으면 빈 days 배열을 반환한다")
+    void returnsEmptyDaysWhenNoApprovedScheduleExists() {
+        User user = User.builder().userId(2L).name("박영희").build();
+        LocalDate startDate = LocalDate.of(2026, 9, 7);
+        LocalDate endDate = LocalDate.of(2026, 9, 11);
+        when(userRepository.findByUserIdAndOrganizationId(2L, 10L))
+                .thenReturn(Optional.of(user));
+        when(scheduleRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(
+                2L, startDate, endDate, List.of(CodeType.WS02)
+        )).thenReturn(List.of());
+
+        var response = service.search(
+                "2", "2026-09-07", "2026-09-11", 10L
+        );
+
+        assertThat(response.days).isEmpty();
+    }
+
+    @Test
+    @DisplayName("빠른 조회 - 사용자가 없거나 다른 조직이면 실패한다")
+    void rejectsUserOutsideAdminOrganization() {
+        when(userRepository.findByUserIdAndOrganizationId(2L, 10L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.search(
+                "2", "2026-09-07", "2026-09-11", 10L
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("빠른 조회 - 시작일이 종료일보다 늦거나 날짜 형식이 잘못되면 실패한다")
+    void rejectsInvalidRange() {
+        User user = User.builder().userId(2L).name("박영희").build();
+        when(userRepository.findByUserIdAndOrganizationId(2L, 10L))
+                .thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> service.search(
+                "2", "2026-09-12", "2026-09-11", 10L
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("조회 기간이 올바르지 않습니다.");
+        assertThatThrownBy(() -> service.search(
+                "2", "2026-09-xx", "2026-09-11", 10L
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("조회 기간이 올바르지 않습니다.");
+    }
+
+    private WorkSchedule schedule(
+            LocalDate date,
+            int startHour,
+            int startMinute,
+            int endHour,
+            int endMinute
+    ) {
+        return WorkSchedule.builder()
+                .date(date)
+                .startTime(LocalTime.of(startHour, startMinute))
+                .endTime(LocalTime.of(endHour, endMinute))
+                .statusCode(CodeType.WS02)
+                .build();
+    }
+}

--- a/src/test/java/com/better/CommuteMate/user/application/AdminUserSearchServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/user/application/AdminUserSearchServiceTest.java
@@ -1,0 +1,85 @@
+package com.better.CommuteMate.user.application;
+
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserSearchServiceTest {
+
+    @Mock UserRepository userRepository;
+
+    AdminUserSearchService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminUserSearchService(userRepository);
+    }
+
+    @Test
+    @DisplayName("관리자 학생 검색 - 같은 조직의 학생을 이름 부분 일치로 조회한다")
+    void searchesStudentsInAdminOrganization() {
+        User first = User.builder().userId(2L).name("박보검").build();
+        User second = User.builder().userId(3L).name("박영희").build();
+        when(userRepository
+                .findAllByOrganizationIdAndRoleCodeAndNameContainingIgnoreCaseOrderByNameAscUserIdAsc(
+                        10L, CodeType.RL01, "박"
+                ))
+                .thenReturn(List.of(first, second));
+
+        var response = service.search(10L, "  박  ");
+
+        assertThat(response.users).hasSize(2);
+        assertThat(response.users.get(0).userId()).isEqualTo("2");
+        assertThat(response.users.get(0).userName()).isEqualTo("박보검");
+        verify(userRepository)
+                .findAllByOrganizationIdAndRoleCodeAndNameContainingIgnoreCaseOrderByNameAscUserIdAsc(
+                        10L, CodeType.RL01, "박"
+                );
+    }
+
+    @Test
+    @DisplayName("관리자 학생 검색 - 결과가 없으면 빈 배열을 반환한다")
+    void returnsEmptyUsersWhenNothingMatches() {
+        when(userRepository
+                .findAllByOrganizationIdAndRoleCodeAndNameContainingIgnoreCaseOrderByNameAscUserIdAsc(
+                        10L, CodeType.RL01, "없는이름"
+                ))
+                .thenReturn(List.of());
+
+        var response = service.search(10L, "없는이름");
+
+        assertThat(response.users).isEmpty();
+    }
+
+    @Test
+    @DisplayName("관리자 학생 검색 - 검색어가 누락되거나 공백이면 실패한다")
+    void rejectsBlankKeyword() {
+        assertThatThrownBy(() -> service.search(10L, null))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("검색어를 입력해주세요.");
+        assertThatThrownBy(() -> service.search(10L, "   "))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("검색어를 입력해주세요.");
+
+        verify(userRepository, never())
+                .findAllByOrganizationIdAndRoleCodeAndNameContainingIgnoreCaseOrderByNameAscUserIdAsc(
+                        10L, CodeType.RL01, ""
+                );
+    }
+}


### PR DESCRIPTION
## 1. 요약 📝
관리자 근로시간표 직접 배치·삭제, 학생 검색 및 사용자별 근로시간표 빠른 조회 API 구현

## 2. 관련 이슈 🔗

## 3. 주요 변경 사항 🔑
- 관리자 근로시간표 직접 배치 및 삭제 API 구현
- 관리자 조직 내 학생 이름 검색 API 구현
- 사용자별 승인 근로시간표 빠른 조회 API 구현

## 4. 기타 💬
**Workplace 생성 정책 논의 필요**
근로시간표를 만들려면 조직에 등록된 workplace가 반드시 필요합니다.
이번 PR에서는 관리자의 organizationId로 근무지를 자동 조회합니다. 등록된 근무지가 없으면 다음 404 응답을 반환합니다.
{
  "isSuccess": false,
  "message": "조직의 근무지를 찾을 수 없습니다.",
  "details": null
}
근무지를 언제 생성할지는 추후 논의가 필요합니다.
조직 생성 시 기본 근무지 자동 생성
시스템 관리자가 별도로 근무지 등록
초기 데이터 또는 DB 마이그레이션으로 생성
이번 PR에는 근무지 생성 기능을 포함하지 않고, 근무지가 없을 때 오류를 반환하도록 처리했습니다.