### PR TITLE
feat: 사용자 근로시간 수정 신청기록 조회 API 구현

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/workchangerequest/repository/WorkChangeRequestRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/workchangerequest/repository/WorkChangeRequestRepository.java
@@ -83,4 +83,57 @@ public interface WorkChangeRequestRepository extends JpaRepository<WorkChangeReq
             @Param("endDate") LocalDate endDate,
             @Param("statusCode") CodeType statusCode
     );
+
+    @Query(
+            value = """
+                    select request
+                    from WorkChangeRequest request
+                    where request.user.userId = :userId
+                      and (:startDate is null or exists (
+                        select item.itemId
+                        from WorkChangeRequestItem item
+                        where item.request = request
+                          and item.date between :startDate and :endDate
+                      ))
+                      and (:statusCode is null or request.statusCode = :statusCode)
+                    """,
+            countQuery = """
+                    select count(request.requestId)
+                    from WorkChangeRequest request
+                    where request.user.userId = :userId
+                      and (:startDate is null or exists (
+                        select item.itemId
+                        from WorkChangeRequestItem item
+                        where item.request = request
+                          and item.date between :startDate and :endDate
+                      ))
+                      and (:statusCode is null or request.statusCode = :statusCode)
+                    """
+    )
+    Page<WorkChangeRequest> findUserRequests(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("statusCode") CodeType statusCode,
+            Pageable pageable
+    );
+
+    @Query("""
+            select count(request.requestId)
+            from WorkChangeRequest request
+            where request.user.userId = :userId
+              and (:startDate is null or exists (
+                select item.itemId
+                from WorkChangeRequestItem item
+                where item.request = request
+                  and item.date between :startDate and :endDate
+              ))
+              and (:statusCode is null or request.statusCode = :statusCode)
+            """)
+    long countUserRequests(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("statusCode") CodeType statusCode
+    );
 }

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
@@ -10,6 +10,7 @@ public enum ScheduleErrorCode implements CustomErrorCode {
     CHANGE_REQUEST_NOT_FOUND("근로시간 수정 요청을 찾을 수 없습니다.", "[Error] : change request not found", HttpStatus.NOT_FOUND),
     CHANGE_REQUEST_CAPACITY_EXCEEDED("해당 시간대의 최대 근무 인원을 초과했습니다.", "[Error] : change request capacity exceeded", HttpStatus.CONFLICT),
     INVALID_CHANGE_REQUEST_STATUS("올바르지 않은 변경 요청 상태입니다.", "[Error] : invalid change request status", HttpStatus.BAD_REQUEST),
+    INVALID_CHANGE_REQUEST_HISTORY_STATUS("올바르지 않은 신청기록 상태입니다.", "[Error] : invalid change request history status", HttpStatus.BAD_REQUEST),
     INVALID_CHANGE_REQUEST_PAGE("페이지 요청 값이 올바르지 않습니다.", "[Error] : invalid change request page", HttpStatus.BAD_REQUEST),
     INVALID_CHANGE_REQUEST_YEAR_MONTH("조회 연도 또는 월 값이 올바르지 않습니다.", "[Error] : invalid change request year or month", HttpStatus.BAD_REQUEST),
     ADMIN_SCHEDULE_QUERY_INVALID("조회 연도 또는 월 값이 올바르지 않습니다.", "[Error] : invalid admin schedule query range", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/better/CommuteMate/schedule/application/WorkChangeRequestHistoryService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/WorkChangeRequestHistoryService.java
@@ -1,0 +1,181 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.workchangerequest.entity.WorkChangeRequest;
+import com.better.CommuteMate.domain.workchangerequest.entity.WorkChangeRequestItem;
+import com.better.CommuteMate.domain.workchangerequest.repository.WorkChangeRequestItemRepository;
+import com.better.CommuteMate.domain.workchangerequest.repository.WorkChangeRequestRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.ScheduleErrorCode;
+import com.better.CommuteMate.schedule.controller.workchangerequest.dtos.WorkChangeRequestHistoryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WorkChangeRequestHistoryService {
+
+    private final WorkChangeRequestRepository requestRepository;
+    private final WorkChangeRequestItemRepository itemRepository;
+
+    public WorkChangeRequestHistoryResponse getHistory(
+            Long userId,
+            Integer year,
+            Integer month,
+            String statusCodeValue,
+            Integer pageValue,
+            Integer sizeValue
+    ) {
+        // TODO: year/month 중 하나만 오는 경우의 처리 규칙이 스펙에 명시되지 않았습니다.
+        //       현재는 둘 다 있을 때만 연월 필터를 적용하고, 하나만 있으면 무시합니다.
+        YearMonth targetMonth = resolveYearMonth(year, month);
+
+        int page = pageValue == null ? 0 : pageValue;
+        int size = sizeValue == null ? 10 : sizeValue;
+        validatePage(page, size);
+
+        StatusFilter statusFilter = parseStatus(statusCodeValue);
+
+        LocalDate startDate = targetMonth != null ? targetMonth.atDay(1) : null;
+        LocalDate endDate = targetMonth != null ? targetMonth.atEndOfMonth() : null;
+
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<WorkChangeRequest> requestPage = requestRepository.findUserRequests(
+                userId, startDate, endDate, statusFilter.code, pageable
+        );
+
+        List<Long> requestIds = requestPage.getContent().stream()
+                .map(WorkChangeRequest::getRequestId)
+                .toList();
+        Map<Long, List<WorkChangeRequestItem>> itemsByRequest = requestIds.isEmpty()
+                ? Map.of()
+                : itemRepository.findAllByRequest_RequestIdIn(requestIds).stream()
+                .collect(Collectors.groupingBy(item -> item.getRequest().getRequestId()));
+
+        List<WorkChangeRequestHistoryResponse.HistoryItem> histories = requestPage.getContent().stream()
+                .map(request -> toHistoryItem(request, itemsByRequest, targetMonth))
+                .toList();
+
+        WorkChangeRequestHistoryResponse.Summary summary = new WorkChangeRequestHistoryResponse.Summary(
+                countUser(userId, startDate, endDate, null),
+                countUser(userId, startDate, endDate, CodeType.CS02),
+                countUser(userId, startDate, endDate, CodeType.CS01),
+                countUser(userId, startDate, endDate, CodeType.CS03)
+        );
+
+        return new WorkChangeRequestHistoryResponse(
+                year,
+                month,
+                statusFilter.responseValue,
+                summary,
+                histories,
+                page,
+                size,
+                requestPage.getTotalElements(),
+                requestPage.getTotalPages()
+        );
+    }
+
+    private YearMonth resolveYearMonth(Integer year, Integer month) {
+        if (year == null || month == null) {
+            return null;
+        }
+        if (year < 1900 || year > 9999) {
+            throw CustomException.of(ScheduleErrorCode.INVALID_CHANGE_REQUEST_YEAR_MONTH);
+        }
+        try {
+            return YearMonth.of(year, month);
+        } catch (DateTimeException e) {
+            throw CustomException.of(ScheduleErrorCode.INVALID_CHANGE_REQUEST_YEAR_MONTH);
+        }
+    }
+
+    private void validatePage(int page, int size) {
+        if (page < 0 || size < 1) {
+            throw CustomException.of(ScheduleErrorCode.INVALID_CHANGE_REQUEST_PAGE);
+        }
+    }
+
+    private StatusFilter parseStatus(String value) {
+        if (value == null || value.isBlank() || value.equalsIgnoreCase("ALL")) {
+            return new StatusFilter(null, "ALL");
+        }
+        try {
+            CodeType code = CodeType.valueOf(value.trim().toUpperCase(Locale.ROOT));
+            if (code != CodeType.CS01 && code != CodeType.CS02 && code != CodeType.CS03) {
+                throw new IllegalArgumentException();
+            }
+            return new StatusFilter(code, code.name());
+        } catch (IllegalArgumentException e) {
+            throw CustomException.of(ScheduleErrorCode.INVALID_CHANGE_REQUEST_HISTORY_STATUS);
+        }
+    }
+
+    private long countUser(Long userId, LocalDate startDate, LocalDate endDate, CodeType statusCode) {
+        return requestRepository.countUserRequests(userId, startDate, endDate, statusCode);
+    }
+
+    private WorkChangeRequestHistoryResponse.HistoryItem toHistoryItem(
+            WorkChangeRequest request,
+            Map<Long, List<WorkChangeRequestItem>> itemsByRequest,
+            YearMonth targetMonth
+    ) {
+        List<WorkChangeRequestItem> items = new ArrayList<>(
+                itemsByRequest.getOrDefault(request.getRequestId(), List.of())
+        );
+        if (targetMonth != null) {
+            items = items.stream()
+                    .filter(item -> YearMonth.from(item.getDate()).equals(targetMonth))
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+        items.sort(Comparator.comparing(WorkChangeRequestItem::getDate)
+                .thenComparing(WorkChangeRequestItem::getStartTime));
+
+        List<WorkChangeRequestHistoryResponse.SlotItem> deleteSlots = items.stream()
+                .filter(item -> item.getChangeTypeCode() == CodeType.CR02)
+                .map(this::toSlotItem)
+                .toList();
+        List<WorkChangeRequestHistoryResponse.SlotItem> addSlots = items.stream()
+                .filter(item -> item.getChangeTypeCode() == CodeType.CR01)
+                .map(this::toSlotItem)
+                .toList();
+
+        return new WorkChangeRequestHistoryResponse.HistoryItem(
+                request.getRequestId(),
+                request.getStatusCode().name(),
+                request.getStatusCode().getCodeValue(),
+                request.getCreatedAt(),
+                request.getProcessedAt(),
+                request.getReason(),
+                request.getRejectReason(),
+                deleteSlots,
+                addSlots
+        );
+    }
+
+    private WorkChangeRequestHistoryResponse.SlotItem toSlotItem(WorkChangeRequestItem item) {
+        return new WorkChangeRequestHistoryResponse.SlotItem(
+                LocalDateTime.of(item.getDate(), item.getStartTime()),
+                LocalDateTime.of(item.getDate(), item.getEndTime()),
+                item.getChangeTypeCode().name()
+        );
+    }
+
+    private record StatusFilter(CodeType code, String responseValue) {}
+}

--- a/src/main/java/com/better/CommuteMate/schedule/controller/workchangerequest/WorkChangeRequestController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/workchangerequest/WorkChangeRequestController.java
@@ -1,0 +1,183 @@
+package com.better.CommuteMate.schedule.controller.workchangerequest;
+
+import com.better.CommuteMate.auth.application.CustomUserDetails;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.schedule.application.WorkChangeRequestHistoryService;
+import com.better.CommuteMate.schedule.controller.workchangerequest.dtos.WorkChangeRequestHistoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "사용자 근로시간 수정 신청", description = "사용자의 근로시간 수정 신청기록 조회 API")
+@RestController
+@RequestMapping("/api/v1/work-change-requests")
+@RequiredArgsConstructor
+public class WorkChangeRequestController {
+
+    private final WorkChangeRequestHistoryService historyService;
+
+    @GetMapping("/history")
+    @Operation(
+            summary = "근무시간 수정 신청기록 조회",
+            description = "로그인한 사용자의 근무시간 변경 신청기록을 조회합니다. " +
+                    "조회 연월, 신청 상태, 페이지 조건을 기준으로 신청 내역을 반환하며, " +
+                    "신청기록은 신청 시각 기준 최신순으로 정렬됩니다. " +
+                    "year와 month를 모두 지정하면 해당 연월로 필터링하고, 하나만 있거나 둘 다 없으면 전체 기간을 조회합니다. " +
+                    "summary는 상태 필터와 관계없이 조회 연월의 전체 신청 현황을 기준으로 계산됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "신청기록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "조회 결과 있음", value = SUCCESS_EXAMPLE),
+                                    @ExampleObject(name = "빈 신청기록", value = EMPTY_EXAMPLE)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "조회 조건이 올바르지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "상태 코드 오류",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "올바르지 않은 신청기록 상태입니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "페이지 요청 오류",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "페이지 요청 값이 올바르지 않습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "연도 또는 월 오류",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "조회 연도 또는 월 값이 올바르지 않습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getHistory(
+            @Parameter(description = "조회 연도. year와 month 모두 있을 때만 연월 필터 적용됩니다.", example = "2026")
+            @RequestParam(required = false) Integer year,
+            @Parameter(description = "조회 월. year와 month 모두 있을 때만 연월 필터 적용됩니다.", example = "4")
+            @RequestParam(required = false) Integer month,
+            @Parameter(description = "신청 상태 필터: ALL(전체, 기본값), CS01(대기), CS02(승인), CS03(거절)", example = "ALL")
+            @RequestParam(required = false) String statusCode,
+            @Parameter(description = "페이지 번호 (기본값: 0)", example = "0")
+            @RequestParam(required = false) Integer page,
+            @Parameter(description = "페이지당 항목 수 (기본값: 10)", example = "10")
+            @RequestParam(required = false) Integer size,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        WorkChangeRequestHistoryResponse details = historyService.getHistory(
+                userDetails.getUserId(),
+                year,
+                month,
+                statusCode,
+                page,
+                size
+        );
+        return ResponseEntity.ok(Response.of(
+                true,
+                "근무시간 신청기록을 조회했습니다.",
+                details
+        ));
+    }
+
+    private static final String SUCCESS_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "근무시간 신청기록을 조회했습니다.",
+              "details": {
+                "year": 2026,
+                "month": 4,
+                "statusCode": "ALL",
+                "summary": {
+                  "totalCount": 4,
+                  "approvedCount": 2,
+                  "pendingCount": 1,
+                  "rejectedCount": 1
+                },
+                "histories": [
+                  {
+                    "requestId": 1,
+                    "statusCode": "CS01",
+                    "statusName": "대기",
+                    "requestedAt": "2026-04-01T10:00:00",
+                    "processedAt": null,
+                    "reason": "사유 입력",
+                    "rejectReason": null,
+                    "deleteSlots": [
+                      { "start": "2026-04-06T13:00:00", "end": "2026-04-06T14:30:00", "changeTypeCode": "CR02" }
+                    ],
+                    "addSlots": [
+                      { "start": "2026-04-09T13:00:00", "end": "2026-04-09T14:30:00", "changeTypeCode": "CR01" }
+                    ]
+                  }
+                ],
+                "page": 0,
+                "size": 10,
+                "totalElements": 4,
+                "totalPages": 1
+              }
+            }
+            """;
+
+    private static final String EMPTY_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "근무시간 신청기록을 조회했습니다.",
+              "details": {
+                "year": 2026,
+                "month": 4,
+                "statusCode": "ALL",
+                "summary": {
+                  "totalCount": 0,
+                  "approvedCount": 0,
+                  "pendingCount": 0,
+                  "rejectedCount": 0
+                },
+                "histories": [],
+                "page": 0,
+                "size": 10,
+                "totalElements": 0,
+                "totalPages": 0
+              }
+            }
+            """;
+}

--- a/src/main/java/com/better/CommuteMate/schedule/controller/workchangerequest/dtos/WorkChangeRequestHistoryResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/workchangerequest/dtos/WorkChangeRequestHistoryResponse.java
@@ -1,0 +1,118 @@
+package com.better.CommuteMate.schedule.controller.workchangerequest.dtos;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class WorkChangeRequestHistoryResponse extends ResponseDetail {
+
+    @Schema(description = "조회 연도 (연월 필터가 없으면 null)", example = "2026")
+    public final Integer year;
+
+    @Schema(description = "조회 월 (연월 필터가 없으면 null)", example = "4")
+    public final Integer month;
+
+    @Schema(description = "신청 상태 필터 (ALL / CS01 / CS02 / CS03)", example = "ALL")
+    public final String statusCode;
+
+    @Schema(description = "조회 기간 전체 신청 현황 요약 (상태 필터 무관)")
+    public final Summary summary;
+
+    @Schema(description = "신청기록 목록 (신청 시각 기준 최신순)")
+    public final List<HistoryItem> histories;
+
+    @Schema(description = "현재 페이지 번호", example = "0")
+    public final int page;
+
+    @Schema(description = "페이지당 항목 수", example = "10")
+    public final int size;
+
+    @Schema(description = "전체 항목 수", example = "4")
+    public final long totalElements;
+
+    @Schema(description = "전체 페이지 수", example = "1")
+    public final int totalPages;
+
+    public WorkChangeRequestHistoryResponse(
+            Integer year,
+            Integer month,
+            String statusCode,
+            Summary summary,
+            List<HistoryItem> histories,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages
+    ) {
+        this.year = year;
+        this.month = month;
+        this.statusCode = statusCode;
+        this.summary = summary;
+        this.histories = histories;
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+
+    public record Summary(
+            @Schema(description = "전체 신청 건수", example = "4") long totalCount,
+            @Schema(description = "승인 건수", example = "2") long approvedCount,
+            @Schema(description = "대기 건수", example = "1") long pendingCount,
+            @Schema(description = "거절 건수", example = "1") long rejectedCount
+    ) {}
+
+    public record HistoryItem(
+            @Schema(description = "신청 ID", example = "1")
+            Long requestId,
+
+            @Schema(description = "신청 상태 코드 (CS01: 대기, CS02: 승인, CS03: 거절)", example = "CS01")
+            String statusCode,
+
+            @Schema(description = "신청 상태 표시명", example = "대기")
+            String statusName,
+
+            @Schema(description = "신청 시각", example = "2026-04-01T10:00:00")
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            LocalDateTime requestedAt,
+
+            @Schema(description = "처리 시각 (미처리 시 null)")
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            LocalDateTime processedAt,
+
+            @Schema(description = "신청 사유", example = "학과 행사 일정으로 인해 근무시간 변경을 요청합니다.")
+            String reason,
+
+            @Schema(description = "거절 사유 (CS03 거절 시에만 존재)")
+            String rejectReason,
+
+            @Schema(description = "삭제 근무시간 목록 (CR02)")
+            List<SlotItem> deleteSlots,
+
+            @Schema(description = "추가 근무시간 목록 (CR01)")
+            List<SlotItem> addSlots
+    ) {}
+
+    public record SlotItem(
+            @Schema(description = "시작 일시", example = "2026-04-06T13:00:00")
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            LocalDateTime start,
+
+            @Schema(description = "종료 일시", example = "2026-04-06T14:30:00")
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            LocalDateTime end,
+
+            @Schema(description = "변경 유형 코드 (CR01: 추가, CR02: 삭제)", example = "CR02")
+            String changeTypeCode
+    ) {}
+}


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
- 사용자가 본인의 근로시간 변경 신청기록을 조회하는 API를 구현
- 조회 연월·신청 상태·페이지 조건으로 신청 내역을 필터링
- 각 신청의 상태·신청/처리 시각·승인/거절 정보·추가 및 삭제 근무시간 정보를 최신순으로 반환

## 2. 관련 이슈 🔗

## 3. 주요 변경 사항 🔑
- `GET /api/v1/work-change-requests/history` 엔드포인트 추가
- `WorkChangeRequestHistoryResponse` DTO 추가
- 신청기록 신청 시각 기준 최신순 정렬
- `summary`를 상태 필터와 무관하게 조회 연월 전체 신청 현황 기준으로 집계 (histories는 statusCode 필터 적용, summary는 미적용)
- work_change_request_item을 change_type_code 기준으로 deleteSlots(CR02) / addSlots(CR01)로 분리
- 검증: year/month 값이 올바르지 않으면 400, statusCode 값이 올바르지 않으면 400, page/size 값이 올바르지 않으면 400

## 4. 기타 💬
- year/month 중 하나만 전달되는 경우 "둘 다 있을 때만 연월 필터 적용, 하나만 있으면 무시"로 처리하고 코드에 TODO 주석 남김. 추후 수정 예정