### PR TITLE
feat: notification 조회·확인 관련 API 구현

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/notification/entity/Notification.java
+++ b/src/main/java/com/better/CommuteMate/domain/notification/entity/Notification.java
@@ -1,0 +1,54 @@
+package com.better.CommuteMate.domain.notification.entity;
+
+import com.better.CommuteMate.global.code.CodeType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "notification", indexes = {
+        @Index(name = "idx_notification_user_id", columnList = "user_id"),
+        @Index(name = "idx_notification_type_code", columnList = "type_code"),
+        @Index(name = "idx_notification_user_created", columnList = "user_id, created_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+    @Id
+    @Column(name = "notification_id", nullable = false, length = 36)
+    private String notificationId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type_code", columnDefinition = "CHAR(4)", nullable = false)
+    private CodeType typeCode;
+
+    @Column(name = "ref_id", length = 36)
+    private String refId;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (notificationId == null) {
+            notificationId = UUID.randomUUID().toString();
+        }
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/better/CommuteMate/domain/notification/entity/NotificationCheckState.java
+++ b/src/main/java/com/better/CommuteMate/domain/notification/entity/NotificationCheckState.java
@@ -1,0 +1,41 @@
+package com.better.CommuteMate.domain.notification.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification_check_state")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NotificationCheckState {
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "last_checked_at")
+    private LocalDateTime lastCheckedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/better/CommuteMate/domain/notification/entity/NotificationCheckState.java
+++ b/src/main/java/com/better/CommuteMate/domain/notification/entity/NotificationCheckState.java
@@ -26,6 +26,10 @@ public class NotificationCheckState {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    public void updateLastCheckedAt(LocalDateTime now) {
+        this.lastCheckedAt = now;
+    }
+
     @PrePersist
     protected void onCreate() {
         if (createdAt == null) {

--- a/src/main/java/com/better/CommuteMate/domain/notification/repository/NotificationCheckStateRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/notification/repository/NotificationCheckStateRepository.java
@@ -1,0 +1,9 @@
+package com.better.CommuteMate.domain.notification.repository;
+
+import com.better.CommuteMate.domain.notification.entity.NotificationCheckState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationCheckStateRepository extends JpaRepository<NotificationCheckState, Long> {
+}

--- a/src/main/java/com/better/CommuteMate/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package com.better.CommuteMate.domain.notification.repository;
+
+import com.better.CommuteMate.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, String> {
+
+    List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/better/CommuteMate/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/notification/repository/NotificationRepository.java
@@ -4,10 +4,15 @@ import com.better.CommuteMate.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, String> {
 
     List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    long countByUserId(Long userId);
+
+    long countByUserIdAndCreatedAtAfter(Long userId, LocalDateTime lastCheckedAt);
 }

--- a/src/main/java/com/better/CommuteMate/global/code/CodeType.java
+++ b/src/main/java/com/better/CommuteMate/global/code/CodeType.java
@@ -33,7 +33,12 @@ public enum CodeType {
 
     // RL: 사용자 역할 (Role)
     RL01("RL", "01", "STUDENT", "학생"),
-    RL02("RL", "02", "ADMIN", "관리자");
+    RL02("RL", "02", "ADMIN", "관리자"),
+
+    // NT: 알림 유형 (Notification Type)
+    NT01("NT", "01", "WORK_CHANGE_APPROVED", "근무 변경 요청 승인"),
+    NT02("NT", "02", "WORK_CHANGE_REJECTED", "근무 변경 요청 거절"),
+    NT03("NT", "03", "WORK_SCHEDULE_OPEN", "근무 신청 시작");
 
     private final String majorCode;
     private final String subCode;

--- a/src/main/java/com/better/CommuteMate/global/security/SecurityConfig.java
+++ b/src/main/java/com/better/CommuteMate/global/security/SecurityConfig.java
@@ -82,6 +82,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/admin/**", "/api/v1/admin/**").hasRole("RL02")
                         // Task API만 인증 필요
                         .requestMatchers("/api/tasks/**", "/api/task-templates/**").authenticated()
+                        // 알림 API 인증 필요
+                        .requestMatchers("/api/v1/notifications/**").authenticated()
                         // 나머지는 모두 허용
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/com/better/CommuteMate/notification/application/NotificationService.java
+++ b/src/main/java/com/better/CommuteMate/notification/application/NotificationService.java
@@ -4,6 +4,7 @@ import com.better.CommuteMate.domain.notification.entity.Notification;
 import com.better.CommuteMate.domain.notification.entity.NotificationCheckState;
 import com.better.CommuteMate.domain.notification.repository.NotificationCheckStateRepository;
 import com.better.CommuteMate.domain.notification.repository.NotificationRepository;
+import com.better.CommuteMate.notification.controller.dtos.NewNotificationResponse;
 import com.better.CommuteMate.notification.controller.dtos.NotificationListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,15 +25,27 @@ public class NotificationService {
         List<Notification> notifications = notificationRepository
                 .findByUserIdOrderByCreatedAtDesc(userId);
 
-        LocalDateTime lastCheckedAt = checkStateRepository.findById(userId)
-                .map(NotificationCheckState::getLastCheckedAt)
-                .orElse(null);
+        LocalDateTime lastCheckedAt = resolveLastCheckedAt(userId);
 
         List<NotificationListResponse.NotificationItem> items = notifications.stream()
                 .map(n -> toItem(n, lastCheckedAt))
                 .toList();
 
         return new NotificationListResponse(items);
+    }
+
+    public NewNotificationResponse getNewNotificationStatus(Long userId) {
+        LocalDateTime lastCheckedAt = resolveLastCheckedAt(userId);
+        long count = lastCheckedAt == null
+                ? notificationRepository.countByUserId(userId)
+                : notificationRepository.countByUserIdAndCreatedAtAfter(userId, lastCheckedAt);
+        return new NewNotificationResponse(count);
+    }
+
+    private LocalDateTime resolveLastCheckedAt(Long userId) {
+        return checkStateRepository.findById(userId)
+                .map(NotificationCheckState::getLastCheckedAt)
+                .orElse(null);
     }
 
     private NotificationListResponse.NotificationItem toItem(

--- a/src/main/java/com/better/CommuteMate/notification/application/NotificationService.java
+++ b/src/main/java/com/better/CommuteMate/notification/application/NotificationService.java
@@ -4,6 +4,7 @@ import com.better.CommuteMate.domain.notification.entity.Notification;
 import com.better.CommuteMate.domain.notification.entity.NotificationCheckState;
 import com.better.CommuteMate.domain.notification.repository.NotificationCheckStateRepository;
 import com.better.CommuteMate.domain.notification.repository.NotificationRepository;
+import com.better.CommuteMate.notification.controller.dtos.CheckNotificationResponse;
 import com.better.CommuteMate.notification.controller.dtos.NewNotificationResponse;
 import com.better.CommuteMate.notification.controller.dtos.NotificationListResponse;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,24 @@ public class NotificationService {
                 ? notificationRepository.countByUserId(userId)
                 : notificationRepository.countByUserIdAndCreatedAtAfter(userId, lastCheckedAt);
         return new NewNotificationResponse(count);
+    }
+
+    @Transactional
+    public CheckNotificationResponse checkNotification(Long userId) {
+        LocalDateTime now = LocalDateTime.now();
+        NotificationCheckState state = checkStateRepository.findById(userId)
+                .orElse(null);
+
+        if (state == null) {
+            state = NotificationCheckState.builder()
+                    .userId(userId)
+                    .lastCheckedAt(now)
+                    .build();
+        } else {
+            state.updateLastCheckedAt(now);
+        }
+        checkStateRepository.save(state);
+        return new CheckNotificationResponse(now);
     }
 
     private LocalDateTime resolveLastCheckedAt(Long userId) {

--- a/src/main/java/com/better/CommuteMate/notification/application/NotificationService.java
+++ b/src/main/java/com/better/CommuteMate/notification/application/NotificationService.java
@@ -1,0 +1,54 @@
+package com.better.CommuteMate.notification.application;
+
+import com.better.CommuteMate.domain.notification.entity.Notification;
+import com.better.CommuteMate.domain.notification.entity.NotificationCheckState;
+import com.better.CommuteMate.domain.notification.repository.NotificationCheckStateRepository;
+import com.better.CommuteMate.domain.notification.repository.NotificationRepository;
+import com.better.CommuteMate.notification.controller.dtos.NotificationListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationCheckStateRepository checkStateRepository;
+
+    public NotificationListResponse getNotifications(Long userId) {
+        List<Notification> notifications = notificationRepository
+                .findByUserIdOrderByCreatedAtDesc(userId);
+
+        LocalDateTime lastCheckedAt = checkStateRepository.findById(userId)
+                .map(NotificationCheckState::getLastCheckedAt)
+                .orElse(null);
+
+        List<NotificationListResponse.NotificationItem> items = notifications.stream()
+                .map(n -> toItem(n, lastCheckedAt))
+                .toList();
+
+        return new NotificationListResponse(items);
+    }
+
+    private NotificationListResponse.NotificationItem toItem(
+            Notification notification, LocalDateTime lastCheckedAt) {
+        boolean isNew = lastCheckedAt == null
+                || notification.getCreatedAt().isAfter(lastCheckedAt);
+
+        return new NotificationListResponse.NotificationItem(
+                notification.getNotificationId(),
+                notification.getTypeCode().name(),
+                notification.getTypeCode().getCodeValue(),
+                notification.getTitle(),
+                notification.getContent(),
+                notification.getRefId(),
+                notification.getCreatedAt(),
+                isNew
+        );
+    }
+}

--- a/src/main/java/com/better/CommuteMate/notification/controller/NotificationController.java
+++ b/src/main/java/com/better/CommuteMate/notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package com.better.CommuteMate.notification.controller;
 import com.better.CommuteMate.auth.application.CustomUserDetails;
 import com.better.CommuteMate.global.controller.dtos.Response;
 import com.better.CommuteMate.notification.application.NotificationService;
+import com.better.CommuteMate.notification.controller.dtos.NewNotificationResponse;
 import com.better.CommuteMate.notification.controller.dtos.NotificationListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -60,6 +61,63 @@ public class NotificationController {
                 details
         ));
     }
+
+    @GetMapping("/new")
+    @Operation(
+            summary = "새 알림 여부 조회",
+            description = "마지막 알림함 확인 시각 이후 생성된 알림의 존재 여부와 개수를 반환합니다. " +
+                    "알림 목록 전체를 조회하지 않고 count 쿼리로만 처리하며, " +
+                    "확인 이력이 없는 경우 사용자의 모든 알림을 새 알림으로 계산합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "새 알림 여부 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "새 알림 있음", value = NEW_NOTIFICATION_EXAMPLE),
+                                    @ExampleObject(name = "새 알림 없음", value = NO_NEW_NOTIFICATION_EXAMPLE)
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getNewNotificationStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        NewNotificationResponse details = notificationService.getNewNotificationStatus(
+                userDetails.getUserId()
+        );
+        return ResponseEntity.ok(Response.of(
+                true,
+                "새 알림 여부를 조회했습니다.",
+                details
+        ));
+    }
+
+    private static final String NEW_NOTIFICATION_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "새 알림 여부를 조회했습니다.",
+              "details": {
+                "hasNewNotification": true,
+                "newNotificationCount": 3
+              }
+            }
+            """;
+
+    private static final String NO_NEW_NOTIFICATION_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "새 알림 여부를 조회했습니다.",
+              "details": {
+                "hasNewNotification": false,
+                "newNotificationCount": 0
+              }
+            }
+            """;
 
     private static final String SUCCESS_EXAMPLE = """
             {

--- a/src/main/java/com/better/CommuteMate/notification/controller/NotificationController.java
+++ b/src/main/java/com/better/CommuteMate/notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package com.better.CommuteMate.notification.controller;
 import com.better.CommuteMate.auth.application.CustomUserDetails;
 import com.better.CommuteMate.global.controller.dtos.Response;
 import com.better.CommuteMate.notification.application.NotificationService;
+import com.better.CommuteMate.notification.controller.dtos.CheckNotificationResponse;
 import com.better.CommuteMate.notification.controller.dtos.NewNotificationResponse;
 import com.better.CommuteMate.notification.controller.dtos.NotificationListResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -96,6 +98,48 @@ public class NotificationController {
                 details
         ));
     }
+
+    @PatchMapping("/check")
+    @Operation(
+            summary = "알림 확인 시각 갱신",
+            description = "사용자가 알림함에 진입한 시점의 서버 시각을 마지막 알림함 확인 시각으로 저장합니다. " +
+                    "기존 확인 상태 데이터가 없으면 새로 생성하며, " +
+                    "이후 새 알림 여부(GET /api/v1/notifications/new)는 갱신된 시각을 기준으로 계산됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "알림 확인 시각 갱신 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = CHECK_EXAMPLE)
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> checkNotification(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        CheckNotificationResponse details = notificationService.checkNotification(
+                userDetails.getUserId()
+        );
+        return ResponseEntity.ok(Response.of(
+                true,
+                "알림 확인 시간이 갱신되었습니다.",
+                details
+        ));
+    }
+
+    private static final String CHECK_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "알림 확인 시간이 갱신되었습니다.",
+              "details": {
+                "lastCheckedAt": "2026-04-10T14:00:00"
+              }
+            }
+            """;
 
     private static final String NEW_NOTIFICATION_EXAMPLE = """
             {

--- a/src/main/java/com/better/CommuteMate/notification/controller/NotificationController.java
+++ b/src/main/java/com/better/CommuteMate/notification/controller/NotificationController.java
@@ -1,0 +1,104 @@
+package com.better.CommuteMate.notification.controller;
+
+import com.better.CommuteMate.auth.application.CustomUserDetails;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.notification.application.NotificationService;
+import com.better.CommuteMate.notification.controller.dtos.NotificationListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "알림", description = "사용자 알림 조회 API")
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    @Operation(
+            summary = "알림 목록 조회",
+            description = "로그인한 사용자의 알림 목록을 생성 시각 기준 최신순으로 조회합니다. " +
+                    "새 알림 여부(isNew)는 마지막 알림함 확인 시각을 기준으로 계산하며, " +
+                    "확인 이력이 없는 경우 모든 알림을 새 알림으로 처리합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "알림 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "알림 있음", value = SUCCESS_EXAMPLE),
+                                    @ExampleObject(name = "알림 없음", value = EMPTY_EXAMPLE)
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getNotifications(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        NotificationListResponse details = notificationService.getNotifications(
+                userDetails.getUserId()
+        );
+        return ResponseEntity.ok(Response.of(
+                true,
+                "알림 목록을 조회했습니다.",
+                details
+        ));
+    }
+
+    private static final String SUCCESS_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "알림 목록을 조회했습니다.",
+              "details": {
+                "notifications": [
+                  {
+                    "notificationId": "550e8400-e29b-41d4-a716-446655440000",
+                    "typeCode": "NT02",
+                    "typeName": "근무 변경 요청 거절",
+                    "title": "근무 시간 수정이 거절되었습니다.",
+                    "content": "4월 6일 13:00-14:30 (1.5h)",
+                    "refId": "9a1b2c3d-e29b-41d4-a716-446655440000",
+                    "createdAt": "2026-03-20T16:21:00",
+                    "isNew": true
+                  },
+                  {
+                    "notificationId": "660e8400-e29b-41d4-a716-446655440001",
+                    "typeCode": "NT01",
+                    "typeName": "근무 변경 요청 승인",
+                    "title": "근무 시간 수정이 승인되었습니다.",
+                    "content": "4월 9일 13:00-14:30 (1.5h)",
+                    "refId": "8b2c3d4e-e29b-41d4-a716-446655440001",
+                    "createdAt": "2026-03-19T10:00:00",
+                    "isNew": false
+                  }
+                ]
+              }
+            }
+            """;
+
+    private static final String EMPTY_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "알림 목록을 조회했습니다.",
+              "details": {
+                "notifications": []
+              }
+            }
+            """;
+}

--- a/src/main/java/com/better/CommuteMate/notification/controller/dtos/CheckNotificationResponse.java
+++ b/src/main/java/com/better/CommuteMate/notification/controller/dtos/CheckNotificationResponse.java
@@ -1,0 +1,25 @@
+package com.better.CommuteMate.notification.controller.dtos;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public class CheckNotificationResponse extends ResponseDetail {
+
+    @Schema(description = "갱신된 마지막 알림함 확인 시각", example = "2026-04-10T14:00:00")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    public final LocalDateTime lastCheckedAt;
+
+    public CheckNotificationResponse(LocalDateTime lastCheckedAt) {
+        this.lastCheckedAt = lastCheckedAt;
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+}

--- a/src/main/java/com/better/CommuteMate/notification/controller/dtos/NewNotificationResponse.java
+++ b/src/main/java/com/better/CommuteMate/notification/controller/dtos/NewNotificationResponse.java
@@ -1,0 +1,27 @@
+package com.better.CommuteMate.notification.controller.dtos;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public class NewNotificationResponse extends ResponseDetail {
+
+    @Schema(description = "새 알림 존재 여부 (newNotificationCount >= 1이면 true)", example = "true")
+    public final boolean hasNewNotification;
+
+    @Schema(description = "새 알림 개수", example = "3")
+    public final long newNotificationCount;
+
+    public NewNotificationResponse(long newNotificationCount) {
+        this.newNotificationCount = newNotificationCount;
+        this.hasNewNotification = newNotificationCount > 0;
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+}

--- a/src/main/java/com/better/CommuteMate/notification/controller/dtos/NotificationListResponse.java
+++ b/src/main/java/com/better/CommuteMate/notification/controller/dtos/NotificationListResponse.java
@@ -1,0 +1,52 @@
+package com.better.CommuteMate.notification.controller.dtos;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class NotificationListResponse extends ResponseDetail {
+
+    @Schema(description = "알림 목록 (생성 시각 기준 최신순)")
+    public final List<NotificationItem> notifications;
+
+    public NotificationListResponse(List<NotificationItem> notifications) {
+        this.notifications = notifications;
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+
+    public record NotificationItem(
+            @Schema(description = "알림 ID (UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+            String notificationId,
+
+            @Schema(description = "알림 유형 코드 (NT01: 근무 변경 요청 승인, NT02: 근무 변경 요청 거절, NT03: 근무 신청 시작)", example = "NT02")
+            String typeCode,
+
+            @Schema(description = "알림 유형 표시명", example = "근무 변경 요청 거절")
+            String typeName,
+
+            @Schema(description = "알림 제목", example = "근무 시간 수정이 거절되었습니다.")
+            String title,
+
+            @Schema(description = "알림 내용 (null 가능)", example = "4월 6일 13:00-14:30 (1.5h)")
+            String content,
+
+            @Schema(description = "참조 대상 ID (UUID, null 가능)", example = "9a1b2c3d-e29b-41d4-a716-446655440000")
+            String refId,
+
+            @Schema(description = "알림 생성 시각", example = "2026-03-20T16:21:00")
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            LocalDateTime createdAt,
+
+            @Schema(description = "새 알림 여부 (마지막 알림함 확인 시각 이후 생성된 경우 true)", example = "true")
+            boolean isNew
+    ) {}
+}


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
- 사용자 알림 기능의 3개 API를 구현.
- 개별 알림의 읽음 여부를 저장하지 않고, 사용자별 마지막 알림함 확인 시각(`notification_check_state.last_checked_at`)을 기준으로 새 알림 여부를 판단하는 방식

## 2. 관련 이슈 🔗

## 3. 주요 변경 사항 🔑
**알림 목록 조회 — `GET /api/v1/notifications`**
- 사용자 알림을 생성 시각 기준 최신순으로 반환
- `isNew`는 `notification_check_state.last_checked_at` 기준으로 계산하며, 확인 이력이 없으면 모든 알림을 새 알림으로 처리
- `Notification`, `NotificationCheckState` 엔티티 및 레포지토리 추가
- `CodeType`에 알림 유형 NT01~NT03 추가
- `/api/v1/notifications/**`를 SecurityConfig 인증 필요 경로에 등록

**새 알림 여부 조회 — `GET /api/v1/notifications/new`**
- 목록 API와 새 알림 판단 기준을 공유하기 위해 `resolveLastCheckedAt()` 공통 메서드로 추출
- `NewNotificationResponse` DTO 추가

**알림 확인 시각 갱신 — `PATCH /api/v1/notifications/check`**
- `notification_check_state`를 upsert 처리
- `NotificationCheckState`에 `updateLastCheckedAt()` 메서드 추가
- `CheckNotificationResponse` DTO 추가


## 4. 기타 💬
