### PR TITLE
[FIX] 관리자 시간표 미설정 월 조회 응답 개선

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkScheduleSettingRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkScheduleSettingRepository.java
@@ -22,6 +22,12 @@ public interface WorkScheduleSettingRepository extends JpaRepository<WorkSchedul
             Integer month
     );
 
+    boolean existsByOrganizationIdAndYearAndMonth(
+            String organizationId,
+            Integer year,
+            Integer month
+    );
+
     // 동일 월의 동시 승인 요청이 같은 정원 값을 보고 모두 통과하지 않도록 설정 행을 잠급니다.
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQueryService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQueryService.java
@@ -28,6 +28,7 @@ public class AdminWorkScheduleQueryService {
 
     private static final List<CodeType> ACTIVE_STATUSES = List.of(CodeType.WS01, CodeType.WS02);
     private static final int SLOT_MINUTES = 30;
+    private static final int DEFAULT_MAX_CONCURRENT_WORKERS = 4;
 
     private final WorkScheduleSettingRepository settingRepository;
     private final WorkSchedulesRepository scheduleRepository;
@@ -43,13 +44,27 @@ public class AdminWorkScheduleQueryService {
         LocalDate endDate = parseDate(endDateValue);
         validateRange(startDate, endDate);
 
-        WorkScheduleSetting setting = settingRepository
+        YearMonth targetMonth = YearMonth.from(startDate);
+        YearMonth previousMonth = targetMonth.minusMonths(1);
+        YearMonth nextMonth = targetMonth.plusMonths(1);
+        boolean hasPrev = hasSetting(organizationId, previousMonth);
+        boolean hasNext = hasSetting(organizationId, nextMonth);
+
+        Optional<WorkScheduleSetting> settingOptional = settingRepository
                 .findByOrganizationIdAndYearAndMonth(
                         organizationId, startDate.getYear(), startDate.getMonthValue()
-                )
-                .orElseThrow(() -> CustomException.of(
-                        ScheduleErrorCode.ADMIN_SCHEDULE_SETTING_NOT_FOUND
-                ));
+                );
+        if (settingOptional.isEmpty()) {
+            return new AdminScheduleRangeResponse(
+                    startDate,
+                    endDate,
+                    DEFAULT_MAX_CONCURRENT_WORKERS,
+                    hasPrev,
+                    hasNext,
+                    List.of()
+            );
+        }
+        WorkScheduleSetting setting = settingOptional.get();
 
         List<WorkSchedule> schedules =
                 scheduleRepository.findAllBySettingAndDateBetweenAndStatusCodeIn(
@@ -81,7 +96,20 @@ public class AdminWorkScheduleQueryService {
         }
 
         return new AdminScheduleRangeResponse(
-                startDate, endDate, setting.getMaxConcurrentWorkers(), days
+                startDate,
+                endDate,
+                setting.getMaxConcurrentWorkers(),
+                hasPrev,
+                hasNext,
+                days
+        );
+    }
+
+    private boolean hasSetting(String organizationId, YearMonth yearMonth) {
+        return settingRepository.existsByOrganizationIdAndYearAndMonth(
+                organizationId,
+                yearMonth.getYear(),
+                yearMonth.getMonthValue()
         );
     }
 

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
@@ -36,9 +36,10 @@ public class AdminWorkScheduleController {
                     description = "근로시간표 조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    name = "조회 성공",
-                                    value = """
+                            examples = {
+                                    @ExampleObject(
+                                            name = "조회 성공",
+                                            value = """
                                             {
                                               "isSuccess": true,
                                               "message": "근로시간표를 조회했습니다.",
@@ -46,6 +47,8 @@ public class AdminWorkScheduleController {
                                                 "startDate": "2026-04-15",
                                                 "endDate": "2026-04-15",
                                                 "maxConcurrentWorkers": 4,
+                                                "hasPrev": true,
+                                                "hasNext": true,
                                                 "days": [{
                                                   "date": "2026-04-15",
                                                   "slots": [{
@@ -63,7 +66,25 @@ public class AdminWorkScheduleController {
                                               }
                                             }
                                             """
-                            )
+                                    ),
+                                    @ExampleObject(
+                                            name = "해당 월 설정 없음",
+                                            value = """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "message": "근로시간표를 조회했습니다.",
+                                                      "details": {
+                                                        "startDate": "2026-04-15",
+                                                        "endDate": "2026-04-15",
+                                                        "maxConcurrentWorkers": 4,
+                                                        "hasPrev": true,
+                                                        "hasNext": false,
+                                                        "days": []
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
             @ApiResponse(
@@ -75,20 +96,6 @@ public class AdminWorkScheduleController {
                                     {
                                       "isSuccess": false,
                                       "message": "조회 연도 또는 월 값이 올바르지 않습니다.",
-                                      "details": null
-                                    }
-                                    """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "해당 월의 스케줄 설정이 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "message": "해당 월의 스케줄 설정을 찾을 수 없습니다.",
                                       "details": null
                                     }
                                     """)

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminScheduleRangeResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/AdminScheduleRangeResponse.java
@@ -15,17 +15,23 @@ public class AdminScheduleRangeResponse extends ResponseDetail {
     @JsonFormat(pattern = "yyyy-MM-dd")
     public final LocalDate endDate;
     public final int maxConcurrentWorkers;
+    public final boolean hasPrev;
+    public final boolean hasNext;
     public final List<Day> days;
 
     public AdminScheduleRangeResponse(
             LocalDate startDate,
             LocalDate endDate,
             int maxConcurrentWorkers,
+            boolean hasPrev,
+            boolean hasNext,
             List<Day> days
     ) {
         this.startDate = startDate;
         this.endDate = endDate;
         this.maxConcurrentWorkers = maxConcurrentWorkers;
+        this.hasPrev = hasPrev;
+        this.hasNext = hasNext;
         this.days = days;
     }
 

--- a/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQueryServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQueryServiceTest.java
@@ -74,6 +74,8 @@ class AdminWorkScheduleQueryServiceTest {
         var response = service.getSchedules("10", "2026-04-15", "2026-04-15", null);
 
         assertThat(response.maxConcurrentWorkers).isEqualTo(4);
+        assertThat(response.hasPrev).isFalse();
+        assertThat(response.hasNext).isFalse();
         assertThat(response.days).hasSize(1);
         assertThat(response.days.get(0).slots()).hasSize(3);
         assertThat(response.days.get(0).slots().get(0).status()).isEqualTo("AVAILABLE");
@@ -94,16 +96,21 @@ class AdminWorkScheduleQueryServiceTest {
     }
 
     @Test
-    @DisplayName("관리자 근로시간표 조회 - 해당 월 설정이 없으면 실패한다")
-    void throwsNotFoundWhenMonthlySettingDoesNotExist() {
+    @DisplayName("관리자 근로시간표 조회 - 해당 월 설정이 없으면 빈 배열과 이전·다음 설정 여부를 반환한다")
+    void returnsEmptyDaysWhenMonthlySettingDoesNotExist() {
         when(settingRepository.findByOrganizationIdAndYearAndMonth("10", 2026, 4))
                 .thenReturn(Optional.empty());
+        when(settingRepository.existsByOrganizationIdAndYearAndMonth("10", 2026, 3))
+                .thenReturn(true);
+        when(settingRepository.existsByOrganizationIdAndYearAndMonth("10", 2026, 5))
+                .thenReturn(false);
 
-        assertThatThrownBy(() -> service.getSchedules(
-                "10", "2026-04-15", "2026-04-15", null
-        ))
-                .isInstanceOf(CustomException.class)
-                .hasMessage("해당 월의 스케줄 설정을 찾을 수 없습니다.");
+        var response = service.getSchedules("10", "2026-04-15", "2026-04-15", null);
+
+        assertThat(response.maxConcurrentWorkers).isEqualTo(4);
+        assertThat(response.hasPrev).isTrue();
+        assertThat(response.hasNext).isFalse();
+        assertThat(response.days).isEmpty();
     }
 
     private WorkScheduleSetting setting() {


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
관리자 근무시간표 조회 시 해당 월의 설정이 없어도 빈 응답을 반환하도록 수정했습니다.

## 2. 관련 이슈 🔗

## 3. 주요 변경 사항 🔑
설정 미존재 시 404 대신 days: [] 반환
이전·다음 달 설정 여부인 hasPrev, hasNext 추가
설정 미존재 시 maxConcurrentWorkers 기본값 4 적용

## 4. 기타 💬
