### PR TITLE
fix: JWT 인증 실패 시 401 응답 및 Swagger 적용

### DIFF
--- a/src/main/java/com/better/CommuteMate/global/config/SecurityOperationCustomizer.java
+++ b/src/main/java/com/better/CommuteMate/global/config/SecurityOperationCustomizer.java
@@ -1,0 +1,58 @@
+package com.better.CommuteMate.global.config;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+/**
+ * @SecurityRequirement(name = "JWT")가 선언된 모든 오퍼레이션에 401 응답을 자동으로 추가합니다.
+ */
+@Component
+public class SecurityOperationCustomizer implements OperationCustomizer {
+
+    private static final String UNAUTHORIZED_EXAMPLE =
+            "{\"isSuccess\":false,\"message\":\"인증이 필요합니다.\",\"details\":null}";
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        if (!hasJwtSecurityRequirement(operation)) {
+            return operation;
+        }
+
+        if (operation.getResponses() == null) {
+            operation.setResponses(new ApiResponses());
+        }
+
+        if (!operation.getResponses().containsKey("401")) {
+            operation.getResponses().addApiResponse("401", buildUnauthorizedResponse());
+        }
+
+        return operation;
+    }
+
+    private boolean hasJwtSecurityRequirement(Operation operation) {
+        if (operation.getSecurity() == null) {
+            return false;
+        }
+        return operation.getSecurity().stream()
+                .anyMatch(req -> req.containsKey("JWT"));
+    }
+
+    private ApiResponse buildUnauthorizedResponse() {
+        Schema<?> schema = new Schema<>();
+        schema.setExample(UNAUTHORIZED_EXAMPLE);
+
+        MediaType mediaType = new MediaType().schema(schema);
+        Content content = new Content().addMediaType("application/json", mediaType);
+
+        return new ApiResponse()
+                .description("인증되지 않은 사용자")
+                .content(content);
+    }
+}

--- a/src/main/java/com/better/CommuteMate/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/better/CommuteMate/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.better.CommuteMate.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("isSuccess", false);
+        body.put("message", "인증이 필요합니다.");
+        body.put("details", null);
+
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/better/CommuteMate/global/security/SecurityConfig.java
+++ b/src/main/java/com/better/CommuteMate/global/security/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
-                                                   JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+                                                   JwtAuthenticationFilter jwtAuthenticationFilter,
+                                                   JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
@@ -86,6 +87,9 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/notifications/**").authenticated()
                         // 나머지는 모두 허용
                         .anyRequest().permitAll()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/better/CommuteMate/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/better/CommuteMate/global/security/jwt/JwtAuthenticationFilter.java
@@ -2,8 +2,10 @@ package com.better.CommuteMate.global.security.jwt;
 
 import com.better.CommuteMate.auth.application.CustomUserDetailsService;
 import com.better.CommuteMate.auth.application.TokenBlacklistService;
+import com.better.CommuteMate.global.security.JwtAuthenticationEntryPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -26,23 +28,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService userDetailsService;
     private final TokenBlacklistService tokenBlacklistService;
+    private final JwtAuthenticationEntryPoint entryPoint;
 
     public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider,
                                    CustomUserDetailsService userDetailsService,
-                                   TokenBlacklistService tokenBlacklistService) {
+                                   TokenBlacklistService tokenBlacklistService,
+                                   JwtAuthenticationEntryPoint entryPoint) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.userDetailsService = userDetailsService;
         this.tokenBlacklistService = tokenBlacklistService;
+        this.entryPoint = entryPoint;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        try {
-            String token = resolveToken(request);
-            if (token != null) {
-                // 토큰 블랙리스트에서 확인
+        String token = resolveToken(request);
+        if (token != null) {
+            // 토큰이 존재하지만 유효하지 않으면 즉시 401 반환 (필터 체인 중단)
+            try {
                 if (tokenBlacklistService.isBlacklisted(token)) {
                     throw new IllegalArgumentException("JWT is blacklisted");
                 }
@@ -55,10 +60,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
+            } catch (Exception ex) {
+                logger.error("JWT authentication error: {}", ex.getMessage());
+                SecurityContextHolder.clearContext();
+                entryPoint.commence(request, response,
+                        new InsufficientAuthenticationException("JWT authentication failed"));
+                return;
             }
-        } catch (Exception ex) {
-            logger.error("JWT authentication error: {}", ex.getMessage());
-            SecurityContextHolder.clearContext();
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/better/CommuteMate/notification/controller/NotificationController.java
+++ b/src/main/java/com/better/CommuteMate/notification/controller/NotificationController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "알림", description = "사용자 알림 조회 API")
+@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
@@ -50,7 +51,6 @@ public class NotificationController {
             ),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
     })
-    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> getNotifications(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
@@ -85,7 +85,6 @@ public class NotificationController {
             ),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
     })
-    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> getNewNotificationStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
@@ -117,7 +116,6 @@ public class NotificationController {
             ),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
     })
-    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> checkNotification(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminScheduleController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "관리자 근무 일정 관리", description = "관리자용 근무 일정 설정 API")
+@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/admin")
 @RequiredArgsConstructor
@@ -138,7 +139,6 @@ public class AdminScheduleController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
             @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
     })
-    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> saveScheduleSetting(
             @Parameter(description = "설정 연도", example = "2026", required = true)
             @PathVariable int year,

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkChangeRequestController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkChangeRequestController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "관리자 근로시간 수정 요청", description = "관리자의 근로시간 수정 요청 조회 API")
+@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/admin/work-change-requests")
 @RequiredArgsConstructor
@@ -95,7 +96,6 @@ public class AdminWorkChangeRequestController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
             @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
     })
-    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> getRequests(
             @Parameter(description = "조회 연도", example = "2026", required = true)
             @RequestParam(required = false) Integer year,
@@ -188,7 +188,6 @@ public class AdminWorkChangeRequestController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
             @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
     })
-    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> processRequest(
             @Parameter(description = "처리할 근로시간 수정 요청 ID", example = "1", required = true)
             @PathVariable Long requestId,
@@ -256,7 +255,6 @@ public class AdminWorkChangeRequestController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
             @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
     })
-    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> bulkApprove(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "관리자 근로시간표", description = "관리자용 근로시간표 조회 API")
+@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/admin/work-schedules")
 @RequiredArgsConstructor
@@ -104,7 +105,6 @@ public class AdminWorkScheduleController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
             @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
     })
-    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> getSchedules(
             @Parameter(description = "조회 시작일", example = "2026-04-15", required = true)
             @RequestParam(required = false) String startDate,

--- a/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 
 @Tag(name = "사용자 근무 일정", description = "사용자 근무 일정 신청 및 조회 API")
+@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/work-schedules")
 @RequiredArgsConstructor

--- a/src/main/java/com/better/CommuteMate/schedule/controller/workchangerequest/WorkChangeRequestController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/workchangerequest/WorkChangeRequestController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "사용자 근로시간 수정 신청", description = "사용자의 근로시간 수정 신청기록 조회 API")
+@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/work-change-requests")
 @RequiredArgsConstructor
@@ -90,7 +91,6 @@ public class WorkChangeRequestController {
             ),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
     })
-    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> getHistory(
             @Parameter(description = "조회 연도. year와 month 모두 있을 때만 연월 필터 적용됩니다.", example = "2026")
             @RequestParam(required = false) Integer year,

--- a/src/test/java/com/better/CommuteMate/attendance/controller/WorkAttendanceControllerTest.java
+++ b/src/test/java/com/better/CommuteMate/attendance/controller/WorkAttendanceControllerTest.java
@@ -47,6 +47,8 @@ class WorkAttendanceControllerTest {
     private com.better.CommuteMate.auth.application.CustomUserDetailsService customUserDetailsService;
     @MockBean
     private com.better.CommuteMate.auth.application.TokenBlacklistService tokenBlacklistService;
+    @MockBean
+    private com.better.CommuteMate.global.security.JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Test
     @DisplayName("QR 토큰 발급 API - 성공")

--- a/src/test/java/com/better/CommuteMate/home/controller/HomeControllerTest.java
+++ b/src/test/java/com/better/CommuteMate/home/controller/HomeControllerTest.java
@@ -38,6 +38,8 @@ class HomeControllerTest {
     private com.better.CommuteMate.auth.application.CustomUserDetailsService customUserDetailsService;
     @MockBean
     private com.better.CommuteMate.auth.application.TokenBlacklistService tokenBlacklistService;
+    @MockBean
+    private com.better.CommuteMate.global.security.JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Test
     @DisplayName("오늘의 근무 시간 조회 API - 성공")


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝

- 만료·누락·변조된 토큰으로 인증이 필요한 엔드포인트를 호출할 때 500 에러가 반환되던 문제를 수정
- 근본 원인: AuthenticationEntryPoint 부재로 JWT 필터의 인증 실패가 Spring 기본 동작으로 흘러 500이 나던 것. 공통 지점(시큐리티 설정) 한 곳을 수정해 모든 인증 실패가 401로 통일되도록 수정
- Swagger 문서에 401 응답을 자동 주입, 표기 대상을 우리 팀(/api/v1) 엔드포인트로 한정함

## 2. 관련 이슈 🔗

https://github.com/konkuk-icteam-student/CommuteMate-backend/issues/115

## 3. 주요 변경 사항 🔑

- `JwtAuthenticationEntryPoint` 생성: 인증 실패 시 공통 응답 포맷의 401 JSON을 직접 반환
- `JwtAuthenticationFilter` 수정: 유효하지 않은 토큰 감지 시 EntryPoint로 위임 후 체인 중단 (기존 500 → 401)
- `SecurityConfig` 수정: `exceptionHandling`에 EntryPoint 등록
- `SecurityOperationCustomizer` 생성: `@SecurityRequirement(name = "JWT")`가 선언된 오퍼레이션에 401 응답을 자동 주입 (엔드포인트별 중복 애노테이션 불필요, 이후 추가되는 API에도 자동 적용)
- `@SecurityRequirement(name = "JWT")`를 /api/v1 경로 컨트롤러에 클래스 레벨로 통일 적용, /api/v1 외 경로(다른 팀 영역)는 문서 표기에서 제외

## 4. 기타 💬

- Swagger 문서 표기만 /api/v1로 좁힌 것이며, 실제 401 인증 처리는 전역 공통(EntryPoint/필터)으로 모든 경로에 동일하게 동작합니다. 다른 팀 경로도 인증 실패 시 401로 응답합니다.
- 403(인가 실패)용 AccessDeniedHandler는 이번 범위(401 통일)에 포함하지 않았습니다. 필요 시 별도 작업으로 분리 예정입니다.
- 인증 관련 테스트(HomeControllerTest, WorkAttendanceControllerTest)에 EntryPoint @MockBean을 추가해 기존 테스트가 깨지지 않도록 했습니다.
