### PR TITLE
[FEAT] 관리자 홈페이지 api 구현

### DIFF
--- a/src/main/java/com/better/CommuteMate/attendance/application/WorkAttendanceService.java
+++ b/src/main/java/com/better/CommuteMate/attendance/application/WorkAttendanceService.java
@@ -93,6 +93,10 @@ public class WorkAttendanceService {
                 .build();
 
         workAttendanceRepository.save(attendance);
+        targetSchedule.markWorking(
+                now.isAfter(toDateTime(targetSchedule, targetSchedule.getStartTime()).plusMinutes(10)),
+                String.valueOf(userId)
+        );
     }
 
     /**
@@ -143,6 +147,7 @@ public class WorkAttendanceService {
                 .build();
 
         workAttendanceRepository.save(attendance);
+        targetSchedule.markCompleted(String.valueOf(userId));
     }
 
     /**

--- a/src/main/java/com/better/CommuteMate/domain/schedule/entity/WorkSchedule.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/entity/WorkSchedule.java
@@ -48,6 +48,15 @@ public class WorkSchedule {
     @Column(name = "status_code", columnDefinition = "CHAR(4)", nullable = false)
     private CodeType statusCode;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "work_status_code", columnDefinition = "CHAR(4)")
+    private CodeType workStatusCode = CodeType.WK01;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "attendance_status_code", columnDefinition = "CHAR(4)")
+    private CodeType attendanceStatusCode;
+
     @Column(name = "created_request_id", length = 36)
     private String createdRequestId;
 
@@ -96,6 +105,23 @@ public class WorkSchedule {
 
     public void cancel(String updatedBy) {
         this.statusCode = CodeType.WS04;
+        this.updatedBy = updatedBy;
+    }
+
+    public void markWorking(boolean late, String updatedBy) {
+        this.workStatusCode = CodeType.WK02;
+        this.attendanceStatusCode = late ? CodeType.AT02 : CodeType.AT01;
+        this.updatedBy = updatedBy;
+    }
+
+    public void markCompleted(String updatedBy) {
+        this.workStatusCode = CodeType.WK03;
+        this.updatedBy = updatedBy;
+    }
+
+    public void markNoShow(boolean absent, String updatedBy) {
+        this.workStatusCode = CodeType.WK04;
+        this.attendanceStatusCode = absent ? CodeType.AT03 : null;
         this.updatedBy = updatedBy;
     }
 

--- a/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
@@ -20,6 +20,12 @@ public interface WorkSchedulesRepository extends JpaRepository<WorkSchedule, Str
      */
     List<WorkSchedule> findAllByDate(LocalDate date);
 
+    List<WorkSchedule> findAllByUser_OrganizationIdAndDateAndStatusCode(
+            Long organizationId,
+            LocalDate date,
+            CodeType statusCode
+    );
+
     /**
      * 특정 사용자의 특정 기간 내 유효한 근무 일정 목록을 조회
      * 신청(WS01), 승인(WS02) 상태만 포함

--- a/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
@@ -26,6 +26,13 @@ public interface WorkSchedulesRepository extends JpaRepository<WorkSchedule, Str
             CodeType statusCode
     );
 
+    List<WorkSchedule> findAllByUser_UserIdInAndDateBetweenAndStatusCode(
+            List<Long> userIds,
+            LocalDate startDate,
+            LocalDate endDate,
+            CodeType statusCode
+    );
+
     /**
      * 특정 사용자의 특정 기간 내 유효한 근무 일정 목록을 조회
      * 신청(WS01), 승인(WS02) 상태만 포함

--- a/src/main/java/com/better/CommuteMate/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/task/repository/TaskRepository.java
@@ -13,6 +13,8 @@ import java.util.List;
 @Repository
 public interface TaskRepository extends JpaRepository<Task, Long> {
 
+    List<Task> findAllByAssignee_OrganizationIdAndTaskDate(Long organizationId, LocalDate taskDate);
+
     /**
      * 특정 날짜의 모든 업무 조회 (시간순 정렬)
      */

--- a/src/main/java/com/better/CommuteMate/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/better/CommuteMate/domain/user/entity/UserProfile.java
@@ -1,0 +1,45 @@
+package com.better.CommuteMate.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserProfile {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "student_id", length = 30)
+    private String studentId;
+
+    @Column(name = "department", length = 100)
+    private String department;
+
+    @Column(name = "grade")
+    private Integer grade;
+
+    @Column(name = "phone_number", length = 30)
+    private String phoneNumber;
+}

--- a/src/main/java/com/better/CommuteMate/domain/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/user/repository/UserProfileRepository.java
@@ -1,0 +1,11 @@
+package com.better.CommuteMate.domain.user.repository;
+
+import com.better.CommuteMate.domain.user.entity.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+    List<UserProfile> findAllByUserIdIn(Collection<Long> userIds);
+}

--- a/src/main/java/com/better/CommuteMate/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/user/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package com.better.CommuteMate.domain.user.repository;
 
 import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.global.code.CodeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.Optional;
@@ -10,4 +13,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByUserId(Long userId);
     boolean existsByEmail(String email);
+
+    Page<User> findAllByOrganizationIdAndRoleCodeAndNameContainingIgnoreCase(
+            Long organizationId,
+            CodeType roleCode,
+            String name,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/better/CommuteMate/domain/workattendance/repository/WorkAttendanceRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/workattendance/repository/WorkAttendanceRepository.java
@@ -1,6 +1,7 @@
 package com.better.CommuteMate.domain.workattendance.repository;
 
 import com.better.CommuteMate.domain.workattendance.entity.WorkAttendance;
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +13,5 @@ public interface WorkAttendanceRepository extends JpaRepository<WorkAttendance, 
     List<WorkAttendance> findByUser_UserIdAndCheckTime(Long userId, LocalDateTime checkTime);
     List<WorkAttendance> findBySchedule_ScheduleId(String scheduleId);
     List<WorkAttendance> findByUser_UserIdAndCheckTimeBetween(Long userId, LocalDateTime start, LocalDateTime end);
+    List<WorkAttendance> findAllByScheduleIn(List<WorkSchedule> schedules);
 }

--- a/src/main/java/com/better/CommuteMate/global/code/CodeType.java
+++ b/src/main/java/com/better/CommuteMate/global/code/CodeType.java
@@ -14,6 +14,17 @@ public enum CodeType {
     WS03("WS", "03", "REJECTED", "반려"),
     WS04("WS", "04", "CANCELLED", "취소"),
 
+    // WK: 실제 근무 상태 (Work State)
+    WK01("WK", "01", "SCHEDULED", "근무 예정"),
+    WK02("WK", "02", "WORKING", "근무 중"),
+    WK03("WK", "03", "COMPLETED", "근무 완료"),
+    WK04("WK", "04", "NO_SHOW", "미출근"),
+
+    // AT: 근태 상태 (Attendance State)
+    AT01("AT", "01", "NORMAL", "정상"),
+    AT02("AT", "02", "LATE", "지각"),
+    AT03("AT", "03", "ABSENT", "결근"),
+
     // CR: 요청 유형 (Change Request Type)
     CR01("CR", "01", "EDIT", "수정 요청"),
     CR02("CR", "02", "DELETE", "삭제 요청"),

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/AdminHomeErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/AdminHomeErrorCode.java
@@ -1,0 +1,41 @@
+package com.better.CommuteMate.global.exceptions.error;
+
+import org.springframework.http.HttpStatus;
+
+public enum AdminHomeErrorCode implements CustomErrorCode {
+    INVALID_DATE(
+            "조회 날짜 값이 올바르지 않습니다.",
+            "[Error] : invalid admin home attendance summary date",
+            HttpStatus.BAD_REQUEST
+    );
+
+    private final String message;
+    private final String logMessage;
+    private final HttpStatus status;
+
+    AdminHomeErrorCode(String message, String logMessage, HttpStatus status) {
+        this.message = message;
+        this.logMessage = logMessage;
+        this.status = status;
+    }
+
+    @Override
+    public String getLogMessage() {
+        return logMessage;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/AdminHomeErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/AdminHomeErrorCode.java
@@ -7,6 +7,11 @@ public enum AdminHomeErrorCode implements CustomErrorCode {
             "조회 날짜 값이 올바르지 않습니다.",
             "[Error] : invalid admin home attendance summary date",
             HttpStatus.BAD_REQUEST
+    ),
+    INVALID_PAGE(
+            "페이지 요청 값이 올바르지 않습니다.",
+            "[Error] : invalid admin home attendance page",
+            HttpStatus.BAD_REQUEST
     );
 
     private final String message;

--- a/src/main/java/com/better/CommuteMate/home/application/AdminHomeService.java
+++ b/src/main/java/com/better/CommuteMate/home/application/AdminHomeService.java
@@ -1,0 +1,124 @@
+package com.better.CommuteMate.home.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.task.entity.Task;
+import com.better.CommuteMate.domain.task.repository.TaskRepository;
+import com.better.CommuteMate.domain.workattendance.entity.WorkAttendance;
+import com.better.CommuteMate.domain.workattendance.repository.WorkAttendanceRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.AdminHomeErrorCode;
+import com.better.CommuteMate.home.controller.dto.AdminAttendanceSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminHomeService {
+
+    private final WorkSchedulesRepository scheduleRepository;
+    private final WorkAttendanceRepository attendanceRepository;
+    private final TaskRepository taskRepository;
+
+    public AdminAttendanceSummaryResponse getAttendanceSummary(
+            Long organizationId,
+            String dateValue
+    ) {
+        LocalDate date = parseDate(dateValue);
+        List<WorkSchedule> schedules =
+                scheduleRepository.findAllByUser_OrganizationIdAndDateAndStatusCode(
+                        organizationId,
+                        date,
+                        CodeType.WS02
+                );
+        List<WorkAttendance> attendances = schedules.isEmpty()
+                ? List.of()
+                : attendanceRepository.findAllByScheduleIn(schedules);
+        Map<String, List<WorkAttendance>> attendanceBySchedule = attendances.stream()
+                .collect(Collectors.groupingBy(
+                        attendance -> attendance.getSchedule().getScheduleId()
+                ));
+        Map<Long, List<WorkSchedule>> schedulesByUser = schedules.stream()
+                .collect(Collectors.groupingBy(schedule -> schedule.getUser().getUserId()));
+
+        int currentWorkingCount = (int) schedulesByUser.values().stream()
+                .filter(userSchedules -> userSchedules.stream()
+                        .anyMatch(schedule -> hasCheckInWithoutCheckOut(
+                                attendanceBySchedule.getOrDefault(schedule.getScheduleId(), List.of())
+                        )))
+                .count();
+        int notCheckedInCount = (int) schedulesByUser.values().stream()
+                .filter(userSchedules -> userSchedules.stream()
+                        .noneMatch(schedule -> hasCheckIn(
+                                attendanceBySchedule.getOrDefault(schedule.getScheduleId(), List.of())
+                        )))
+                .count();
+        int lateCount = (int) schedulesByUser.values().stream()
+                .filter(userSchedules -> userSchedules.stream()
+                        .anyMatch(schedule -> isLate(
+                                schedule,
+                                attendanceBySchedule.getOrDefault(schedule.getScheduleId(), List.of())
+                        )))
+                .count();
+
+        List<Task> tasks =
+                taskRepository.findAllByAssignee_OrganizationIdAndTaskDate(organizationId, date);
+        int completedTaskCount = (int) tasks.stream()
+                .filter(task -> Boolean.TRUE.equals(task.getIsCompleted()))
+                .count();
+
+        return new AdminAttendanceSummaryResponse(
+                date,
+                currentWorkingCount,
+                notCheckedInCount,
+                lateCount,
+                new AdminAttendanceSummaryResponse.TodayTask(
+                        completedTaskCount,
+                        tasks.size()
+                )
+        );
+    }
+
+    private LocalDate parseDate(String value) {
+        if (value == null || value.isBlank()) {
+            throw CustomException.of(AdminHomeErrorCode.INVALID_DATE);
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw CustomException.of(AdminHomeErrorCode.INVALID_DATE);
+        }
+    }
+
+    private boolean hasCheckIn(List<WorkAttendance> attendances) {
+        return attendances.stream()
+                .anyMatch(attendance -> attendance.getCheckTypeCode() == CodeType.CT01);
+    }
+
+    private boolean hasCheckInWithoutCheckOut(List<WorkAttendance> attendances) {
+        boolean checkedIn = hasCheckIn(attendances);
+        boolean checkedOut = attendances.stream()
+                .anyMatch(attendance -> attendance.getCheckTypeCode() == CodeType.CT02);
+        return checkedIn && !checkedOut;
+    }
+
+    private boolean isLate(WorkSchedule schedule, List<WorkAttendance> attendances) {
+        LocalDateTime scheduledStart =
+                LocalDateTime.of(schedule.getDate(), schedule.getStartTime());
+        return attendances.stream()
+                .filter(attendance -> attendance.getCheckTypeCode() == CodeType.CT01)
+                .map(WorkAttendance::getCheckTime)
+                .anyMatch(checkIn -> checkIn.isAfter(scheduledStart));
+    }
+}

--- a/src/main/java/com/better/CommuteMate/home/application/AdminUserAttendanceService.java
+++ b/src/main/java/com/better/CommuteMate/home/application/AdminUserAttendanceService.java
@@ -1,0 +1,311 @@
+package com.better.CommuteMate.home.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.entity.WorkScheduleSetting;
+import com.better.CommuteMate.domain.schedule.repository.WorkScheduleSettingRepository;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.entity.UserProfile;
+import com.better.CommuteMate.domain.user.repository.UserProfileRepository;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.domain.workattendance.entity.WorkAttendance;
+import com.better.CommuteMate.domain.workattendance.repository.WorkAttendanceRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.AdminHomeErrorCode;
+import com.better.CommuteMate.home.controller.dto.AdminUserAttendancePageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserAttendanceService {
+
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final WorkSchedulesRepository scheduleRepository;
+    private final WorkAttendanceRepository attendanceRepository;
+    private final WorkScheduleSettingRepository settingRepository;
+
+    public AdminUserAttendancePageResponse getUserAttendance(
+            Long organizationId,
+            String dateValue,
+            String userName,
+            Integer pageValue,
+            Integer sizeValue
+    ) {
+        LocalDate date = parseDate(dateValue);
+        int page = pageValue == null ? 0 : pageValue;
+        int size = sizeValue == null ? 6 : sizeValue;
+        if (page < 0 || size < 1) {
+            throw CustomException.of(AdminHomeErrorCode.INVALID_PAGE);
+        }
+
+        Page<User> users = userRepository
+                .findAllByOrganizationIdAndRoleCodeAndNameContainingIgnoreCase(
+                        organizationId,
+                        CodeType.RL01,
+                        userName == null ? "" : userName.trim(),
+                        PageRequest.of(page, size)
+                );
+        List<Long> userIds = users.getContent().stream().map(User::getUserId).toList();
+        Map<Long, UserProfile> profiles = userProfileRepository.findAllByUserIdIn(userIds).stream()
+                .collect(Collectors.toMap(UserProfile::getUserId, profile -> profile));
+
+        YearMonth month = YearMonth.from(date);
+        LocalDate monthStart = month.atDay(1);
+        LocalDate monthEnd = month.atEndOfMonth();
+        LocalDate weekStart = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEnd = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        List<WorkSchedule> schedules = userIds.isEmpty()
+                ? List.of()
+                : scheduleRepository.findAllByUser_UserIdInAndDateBetweenAndStatusCode(
+                        userIds, monthStart, monthEnd, CodeType.WS02
+                );
+        List<WorkAttendance> attendances = schedules.isEmpty()
+                ? List.of()
+                : attendanceRepository.findAllByScheduleIn(schedules);
+        Map<String, List<WorkAttendance>> attendancesBySchedule = attendances.stream()
+                .collect(Collectors.groupingBy(
+                        attendance -> attendance.getSchedule().getScheduleId()
+                ));
+        Map<Long, List<WorkSchedule>> schedulesByUser = schedules.stream()
+                .collect(Collectors.groupingBy(schedule -> schedule.getUser().getUserId()));
+        Optional<WorkScheduleSetting> setting =
+                settingRepository.findByOrganizationIdAndYearAndMonth(
+                        String.valueOf(organizationId), date.getYear(), date.getMonthValue()
+                );
+        int weeklyLimit = setting.map(WorkScheduleSetting::getWeeklyMaxMinutes).orElse(0);
+        int monthlyLimit = setting.map(WorkScheduleSetting::getMonthlyMaxMinutes).orElse(0);
+        LocalDateTime referenceTime = referenceTime(date);
+
+        List<AdminUserAttendancePageResponse.UserAttendance> details = users.getContent().stream()
+                .map(user -> {
+                    UserProfile profile = profiles.get(user.getUserId());
+                    List<WorkSchedule> userSchedules =
+                            schedulesByUser.getOrDefault(user.getUserId(), List.of());
+                    List<WorkSchedule> dailySchedules = userSchedules.stream()
+                            .filter(schedule -> schedule.getDate().equals(date))
+                            .toList();
+                    Status status = determineStatus(
+                            dailySchedules, attendancesBySchedule, referenceTime
+                    );
+                    LateSummary late = calculateLateSummary(
+                            userSchedules, attendancesBySchedule
+                    );
+                    int weeklyWorked = calculateWorkedMinutes(
+                            userSchedules,
+                            attendancesBySchedule,
+                            schedule -> !schedule.getDate().isBefore(weekStart)
+                                    && !schedule.getDate().isAfter(weekEnd),
+                            referenceTime
+                    );
+                    int monthlyWorked = calculateWorkedMinutes(
+                            userSchedules,
+                            attendancesBySchedule,
+                            schedule -> true,
+                            referenceTime
+                    );
+                    return new AdminUserAttendancePageResponse.UserAttendance(
+                            String.valueOf(user.getUserId()),
+                            user.getName(),
+                            profile == null ? null : profile.getDepartment(),
+                            profile == null ? null : profile.getStudentId(),
+                            status.workStatusCode,
+                            status.attendanceStatusCode,
+                            late.count,
+                            late.minutes,
+                            weeklyWorked,
+                            weeklyLimit,
+                            monthlyWorked,
+                            monthlyLimit
+                    );
+                })
+                .toList();
+
+        return new AdminUserAttendancePageResponse(
+                date,
+                details,
+                page,
+                size,
+                users.getTotalElements(),
+                users.getTotalPages()
+        );
+    }
+
+    private LocalDate parseDate(String value) {
+        if (value == null || value.isBlank()) {
+            throw CustomException.of(AdminHomeErrorCode.INVALID_DATE);
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw CustomException.of(AdminHomeErrorCode.INVALID_DATE);
+        }
+    }
+
+    private LocalDateTime referenceTime(LocalDate date) {
+        LocalDate today = LocalDate.now();
+        if (date.isBefore(today)) {
+            return date.plusDays(1).atStartOfDay();
+        }
+        if (date.isAfter(today)) {
+            return date.atStartOfDay();
+        }
+        return LocalDateTime.now();
+    }
+
+    private Status determineStatus(
+            List<WorkSchedule> schedules,
+            Map<String, List<WorkAttendance>> attendancesBySchedule,
+            LocalDateTime referenceTime
+    ) {
+        if (schedules.isEmpty()) {
+            return new Status(null, null);
+        }
+        List<ScheduleStatus> statuses = schedules.stream()
+                .sorted(Comparator.comparing(WorkSchedule::getStartTime))
+                .map(schedule -> scheduleStatus(
+                        schedule,
+                        attendancesBySchedule.getOrDefault(schedule.getScheduleId(), List.of()),
+                        referenceTime
+                ))
+                .toList();
+
+        return statuses.stream()
+                .filter(status -> CodeType.WK02.name().equals(status.workStatusCode))
+                .map(ScheduleStatus::toStatus)
+                .findFirst()
+                .or(() -> statuses.stream()
+                        .filter(status -> CodeType.AT03.name().equals(status.attendanceStatusCode))
+                        .map(ScheduleStatus::toStatus)
+                        .findFirst())
+                .or(() -> statuses.stream()
+                        .filter(status -> CodeType.WK04.name().equals(status.workStatusCode))
+                        .map(ScheduleStatus::toStatus)
+                        .findFirst())
+                .or(() -> statuses.stream()
+                        .filter(status -> CodeType.WK01.name().equals(status.workStatusCode))
+                        .map(ScheduleStatus::toStatus)
+                        .findFirst())
+                .orElseGet(() -> statuses.get(statuses.size() - 1).toStatus());
+    }
+
+    private ScheduleStatus scheduleStatus(
+            WorkSchedule schedule,
+            List<WorkAttendance> attendances,
+            LocalDateTime referenceTime
+    ) {
+        Optional<LocalDateTime> checkIn = attendances.stream()
+                .filter(attendance -> attendance.getCheckTypeCode() == CodeType.CT01)
+                .map(WorkAttendance::getCheckTime)
+                .min(Comparator.naturalOrder());
+        boolean checkedOut = attendances.stream()
+                .anyMatch(attendance -> attendance.getCheckTypeCode() == CodeType.CT02);
+        LocalDateTime start = LocalDateTime.of(schedule.getDate(), schedule.getStartTime());
+        LocalDateTime end = LocalDateTime.of(schedule.getDate(), schedule.getEndTime());
+
+        if (checkIn.isPresent()) {
+            String attendanceCode = checkIn.get().isAfter(start.plusMinutes(10))
+                    ? CodeType.AT02.name()
+                    : CodeType.AT01.name();
+            return new ScheduleStatus(
+                    checkedOut ? CodeType.WK03.name() : CodeType.WK02.name(),
+                    attendanceCode
+            );
+        }
+        if (referenceTime.isAfter(end)) {
+            return new ScheduleStatus(CodeType.WK04.name(), CodeType.AT03.name());
+        }
+        if (referenceTime.isAfter(start.plusMinutes(10))) {
+            return new ScheduleStatus(CodeType.WK04.name(), null);
+        }
+        return new ScheduleStatus(CodeType.WK01.name(), null);
+    }
+
+    private LateSummary calculateLateSummary(
+            List<WorkSchedule> schedules,
+            Map<String, List<WorkAttendance>> attendancesBySchedule
+    ) {
+        int count = 0;
+        int minutes = 0;
+        for (WorkSchedule schedule : schedules) {
+            Optional<LocalDateTime> checkIn = attendancesBySchedule
+                    .getOrDefault(schedule.getScheduleId(), List.of()).stream()
+                    .filter(attendance -> attendance.getCheckTypeCode() == CodeType.CT01)
+                    .map(WorkAttendance::getCheckTime)
+                    .min(Comparator.naturalOrder());
+            LocalDateTime start = LocalDateTime.of(schedule.getDate(), schedule.getStartTime());
+            if (checkIn.isPresent() && checkIn.get().isAfter(start.plusMinutes(10))) {
+                count++;
+                minutes += (int) Duration.between(start, checkIn.get()).toMinutes();
+            }
+        }
+        return new LateSummary(count, minutes);
+    }
+
+    private int calculateWorkedMinutes(
+            List<WorkSchedule> schedules,
+            Map<String, List<WorkAttendance>> attendancesBySchedule,
+            Predicate<WorkSchedule> include,
+            LocalDateTime referenceTime
+    ) {
+        long total = 0;
+        for (WorkSchedule schedule : schedules.stream().filter(include).toList()) {
+            List<WorkAttendance> attendances =
+                    attendancesBySchedule.getOrDefault(schedule.getScheduleId(), List.of());
+            Optional<LocalDateTime> checkIn = attendances.stream()
+                    .filter(attendance -> attendance.getCheckTypeCode() == CodeType.CT01)
+                    .map(WorkAttendance::getCheckTime)
+                    .min(Comparator.naturalOrder());
+            if (checkIn.isEmpty()) {
+                continue;
+            }
+            LocalDateTime scheduledStart =
+                    LocalDateTime.of(schedule.getDate(), schedule.getStartTime());
+            LocalDateTime scheduledEnd =
+                    LocalDateTime.of(schedule.getDate(), schedule.getEndTime());
+            LocalDateTime start = checkIn.get().isBefore(scheduledStart)
+                    ? scheduledStart
+                    : checkIn.get();
+            LocalDateTime end = attendances.stream()
+                    .filter(attendance -> attendance.getCheckTypeCode() == CodeType.CT02)
+                    .map(WorkAttendance::getCheckTime)
+                    .min(Comparator.naturalOrder())
+                    .orElse(referenceTime);
+            if (end.isAfter(scheduledEnd)) {
+                end = scheduledEnd;
+            }
+            if (end.isAfter(start)) {
+                total += Duration.between(start, end).toMinutes();
+            }
+        }
+        return Math.toIntExact(total);
+    }
+
+    private record Status(String workStatusCode, String attendanceStatusCode) {}
+    private record ScheduleStatus(String workStatusCode, String attendanceStatusCode) {
+        private Status toStatus() {
+            return new Status(workStatusCode, attendanceStatusCode);
+        }
+    }
+    private record LateSummary(int count, int minutes) {}
+}

--- a/src/main/java/com/better/CommuteMate/home/controller/AdminHomeController.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/AdminHomeController.java
@@ -1,0 +1,103 @@
+package com.better.CommuteMate.home.controller;
+
+import com.better.CommuteMate.auth.application.CustomUserDetails;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.home.application.AdminHomeService;
+import com.better.CommuteMate.home.controller.dto.AdminAttendanceSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "관리자 홈", description = "관리자 홈 화면 API")
+@RestController
+@RequestMapping("/api/v1/admin/home")
+@RequiredArgsConstructor
+public class AdminHomeController {
+
+    private final AdminHomeService adminHomeService;
+
+    @GetMapping("/attendance-summary")
+    @Operation(
+            summary = "오늘 근로현황 조회",
+            description = "지정한 날짜의 현재 근무 중, 미출근, 지각 인원과 업무 완료 현황을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "오늘 근로현황 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "조회 성공",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "message": "오늘 근로현황을 조회했습니다.",
+                                              "details": {
+                                                "date": "2026-04-15",
+                                                "currentWorkingCount": 3,
+                                                "notCheckedInCount": 3,
+                                                "lateCount": 3,
+                                                "todayTask": {
+                                                  "completedCount": 1,
+                                                  "totalCount": 6
+                                                }
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "조회 날짜 값이 올바르지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "잘못된 날짜",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "message": "조회 날짜 값이 올바르지 않습니다.",
+                                              "details": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getAttendanceSummary(
+            @Parameter(
+                    description = "조회 날짜 (yyyy-MM-dd)",
+                    example = "2026-04-15",
+                    required = true
+            )
+            @RequestParam(required = false) String date,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long organizationId = userDetails.getUser().getOrganizationId();
+        AdminAttendanceSummaryResponse details =
+                adminHomeService.getAttendanceSummary(organizationId, date);
+        return ResponseEntity.ok(Response.of(
+                true,
+                "오늘 근로현황을 조회했습니다.",
+                details
+        ));
+    }
+
+}

--- a/src/main/java/com/better/CommuteMate/home/controller/AdminHomeController.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/AdminHomeController.java
@@ -90,7 +90,7 @@ public class AdminHomeController {
                     example = "2026-04-15",
                     required = true
             )
-            @RequestParam(required = false) String date,
+            @RequestParam String date,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long organizationId = userDetails.getUser().getOrganizationId();

--- a/src/main/java/com/better/CommuteMate/home/controller/AdminHomeController.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/AdminHomeController.java
@@ -3,7 +3,9 @@ package com.better.CommuteMate.home.controller;
 import com.better.CommuteMate.auth.application.CustomUserDetails;
 import com.better.CommuteMate.global.controller.dtos.Response;
 import com.better.CommuteMate.home.application.AdminHomeService;
+import com.better.CommuteMate.home.application.AdminUserAttendanceService;
 import com.better.CommuteMate.home.controller.dto.AdminAttendanceSummaryResponse;
+import com.better.CommuteMate.home.controller.dto.AdminUserAttendancePageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminHomeController {
 
     private final AdminHomeService adminHomeService;
+    private final AdminUserAttendanceService adminUserAttendanceService;
 
     @GetMapping("/attendance-summary")
     @Operation(
@@ -96,6 +99,96 @@ public class AdminHomeController {
         return ResponseEntity.ok(Response.of(
                 true,
                 "오늘 근로현황을 조회했습니다.",
+                details
+        ));
+    }
+
+    @GetMapping("/attendance-status")
+    @Operation(
+            summary = "인원별 근태 현황 조회",
+            description = """
+                    지정 날짜 기준 조직 구성원의 근무·근태 상태와 해당 주/월 누적 근무시간을 조회합니다.
+                    근무 상태: WK01 근무 예정, WK02 근무 중, WK03 근무 완료, WK04 미출근.
+                    근태 상태: AT01 정상, AT02 지각(예정 시작 10분 초과 후 출근), AT03 결근.
+                    근태 상태가 없거나 해당 날짜에 근무 일정이 없으면 코드가 null입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "인원별 근태 현황 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "message": "인원별 근태 현황을 조회했습니다.",
+                                      "details": {
+                                        "date": "2026-04-15",
+                                        "users": [{
+                                          "userId": "1",
+                                          "userName": "최지훈",
+                                          "department": "정보보호학부",
+                                          "studentId": "202311306",
+                                          "workStatusCode": "WK02",
+                                          "attendanceStatusCode": "AT02",
+                                          "lateCount": 1,
+                                          "lateMinutes": 18,
+                                          "weeklyWorkedMinutes": 270,
+                                          "weeklyLimitMinutes": 540,
+                                          "monthlyWorkedMinutes": 810,
+                                          "monthlyLimitMinutes": 1620
+                                        }],
+                                        "page": 0,
+                                        "size": 6,
+                                        "totalElements": 18,
+                                        "totalPages": 3
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "날짜 또는 페이지 요청 값이 올바르지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "잘못된 날짜", value = """
+                                            {"isSuccess":false,"message":"조회 날짜 값이 올바르지 않습니다.","details":null}
+                                            """),
+                                    @ExampleObject(name = "잘못된 페이지", value = """
+                                            {"isSuccess":false,"message":"페이지 요청 값이 올바르지 않습니다.","details":null}
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getUserAttendance(
+            @Parameter(description = "조회 날짜 (yyyy-MM-dd)", example = "2026-04-15", required = true)
+            @RequestParam(required = false) String date,
+            @Parameter(description = "이름 검색(부분 일치)", example = "김")
+            @RequestParam(required = false) String userName,
+            @Parameter(description = "페이지 번호", example = "0")
+            @RequestParam(required = false) Integer page,
+            @Parameter(description = "페이지 크기", example = "6")
+            @RequestParam(required = false) Integer size,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        AdminUserAttendancePageResponse details =
+                adminUserAttendanceService.getUserAttendance(
+                        userDetails.getUser().getOrganizationId(),
+                        date,
+                        userName,
+                        page,
+                        size
+                );
+        return ResponseEntity.ok(Response.of(
+                true,
+                "인원별 근태 현황을 조회했습니다.",
                 details
         ));
     }

--- a/src/main/java/com/better/CommuteMate/home/controller/dto/AdminAttendanceSummaryResponse.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/dto/AdminAttendanceSummaryResponse.java
@@ -1,0 +1,36 @@
+package com.better.CommuteMate.home.controller.dto;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public class AdminAttendanceSummaryResponse extends ResponseDetail {
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    public final LocalDate date;
+    public final int currentWorkingCount;
+    public final int notCheckedInCount;
+    public final int lateCount;
+    public final TodayTask todayTask;
+
+    public AdminAttendanceSummaryResponse(
+            LocalDate date,
+            int currentWorkingCount,
+            int notCheckedInCount,
+            int lateCount,
+            TodayTask todayTask
+    ) {
+        this.date = date;
+        this.currentWorkingCount = currentWorkingCount;
+        this.notCheckedInCount = notCheckedInCount;
+        this.lateCount = lateCount;
+        this.todayTask = todayTask;
+    }
+
+    public record TodayTask(
+            int completedCount,
+            int totalCount
+    ) {
+    }
+}

--- a/src/main/java/com/better/CommuteMate/home/controller/dto/AdminUserAttendancePageResponse.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/dto/AdminUserAttendancePageResponse.java
@@ -1,0 +1,50 @@
+package com.better.CommuteMate.home.controller.dto;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class AdminUserAttendancePageResponse extends ResponseDetail {
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    public final LocalDate date;
+    public final List<UserAttendance> users;
+    public final int page;
+    public final int size;
+    public final long totalElements;
+    public final int totalPages;
+
+    public AdminUserAttendancePageResponse(
+            LocalDate date,
+            List<UserAttendance> users,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages
+    ) {
+        this.date = date;
+        this.users = users;
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+    }
+
+    public record UserAttendance(
+            String userId,
+            String userName,
+            String department,
+            String studentId,
+            String workStatusCode,
+            String attendanceStatusCode,
+            int lateCount,
+            int lateMinutes,
+            int weeklyWorkedMinutes,
+            int weeklyLimitMinutes,
+            int monthlyWorkedMinutes,
+            int monthlyLimitMinutes
+    ) {
+    }
+}

--- a/src/test/java/com/better/CommuteMate/home/application/AdminUserAttendanceServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/home/application/AdminUserAttendanceServiceTest.java
@@ -1,0 +1,140 @@
+package com.better.CommuteMate.home.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.entity.WorkScheduleSetting;
+import com.better.CommuteMate.domain.schedule.repository.WorkScheduleSettingRepository;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.entity.UserProfile;
+import com.better.CommuteMate.domain.user.repository.UserProfileRepository;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.domain.workattendance.entity.WorkAttendance;
+import com.better.CommuteMate.domain.workattendance.repository.WorkAttendanceRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserAttendanceServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock UserProfileRepository userProfileRepository;
+    @Mock WorkSchedulesRepository scheduleRepository;
+    @Mock WorkAttendanceRepository attendanceRepository;
+    @Mock WorkScheduleSettingRepository settingRepository;
+
+    AdminUserAttendanceService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminUserAttendanceService(
+                userRepository,
+                userProfileRepository,
+                scheduleRepository,
+                attendanceRepository,
+                settingRepository
+        );
+    }
+
+    @Test
+    void returnsWorkingAndLateCodesWithProfileAndPagination() {
+        LocalDate date = LocalDate.now();
+        LocalTime start = LocalTime.now().minusMinutes(30).withSecond(0).withNano(0);
+        LocalTime end = LocalTime.now().plusMinutes(30).withSecond(0).withNano(0);
+        User user = User.builder()
+                .userId(1L)
+                .organizationId(10L)
+                .name("최지훈")
+                .roleCode(CodeType.RL01)
+                .build();
+        UserProfile profile = UserProfile.builder()
+                .userId(1L)
+                .user(user)
+                .department("정보보호학부")
+                .studentId("202311306")
+                .grade(2)
+                .phoneNumber("010-0000-0000")
+                .build();
+        WorkSchedule schedule = WorkSchedule.builder()
+                .scheduleId("schedule-1")
+                .user(user)
+                .date(date)
+                .startTime(start)
+                .endTime(end)
+                .statusCode(CodeType.WS02)
+                .build();
+        WorkAttendance checkIn = WorkAttendance.builder()
+                .schedule(schedule)
+                .user(user)
+                .checkTypeCode(CodeType.CT01)
+                .checkTime(LocalDateTime.of(date, start.plusMinutes(11)))
+                .build();
+        WorkScheduleSetting setting = WorkScheduleSetting.builder()
+                .weeklyMaxMinutes(540)
+                .monthlyMaxMinutes(1620)
+                .build();
+        PageRequest pageable = PageRequest.of(0, 6);
+
+        when(userRepository.findAllByOrganizationIdAndRoleCodeAndNameContainingIgnoreCase(
+                10L, CodeType.RL01, "", pageable
+        )).thenReturn(new PageImpl<>(List.of(user), pageable, 1));
+        when(userProfileRepository.findAllByUserIdIn(List.of(1L)))
+                .thenReturn(List.of(profile));
+        when(scheduleRepository.findAllByUser_UserIdInAndDateBetweenAndStatusCode(
+                List.of(1L), date.withDayOfMonth(1), date.withDayOfMonth(date.lengthOfMonth()), CodeType.WS02
+        )).thenReturn(List.of(schedule));
+        when(attendanceRepository.findAllByScheduleIn(List.of(schedule)))
+                .thenReturn(List.of(checkIn));
+        when(settingRepository.findByOrganizationIdAndYearAndMonth(
+                "10", date.getYear(), date.getMonthValue()
+        )).thenReturn(Optional.of(setting));
+
+        var response = service.getUserAttendance(10L, date.toString(), null, null, null);
+
+        assertThat(response.page).isZero();
+        assertThat(response.size).isEqualTo(6);
+        assertThat(response.totalElements).isEqualTo(1);
+        assertThat(response.users).hasSize(1);
+        assertThat(response.users.get(0).department()).isEqualTo("정보보호학부");
+        assertThat(response.users.get(0).workStatusCode()).isEqualTo("WK02");
+        assertThat(response.users.get(0).attendanceStatusCode()).isEqualTo("AT02");
+        assertThat(response.users.get(0).lateCount()).isEqualTo(1);
+        assertThat(response.users.get(0).lateMinutes()).isEqualTo(11);
+        assertThat(response.users.get(0).weeklyLimitMinutes()).isEqualTo(540);
+        assertThat(response.users.get(0).monthlyLimitMinutes()).isEqualTo(1620);
+    }
+
+    @Test
+    void rejectsInvalidPage() {
+        assertThatThrownBy(() ->
+                service.getUserAttendance(10L, "2026-04-15", null, -1, 6)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessage("페이지 요청 값이 올바르지 않습니다.");
+    }
+
+    @Test
+    void rejectsInvalidDate() {
+        assertThatThrownBy(() ->
+                service.getUserAttendance(10L, "invalid", null, 0, 6)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessage("조회 날짜 값이 올바르지 않습니다.");
+    }
+}


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
관리자 홈 근로현황 및 인원별 근태 조회 API를 구현했습니다!
## 2. 관련 이슈 🔗

## 3. 주요 변경 사항 🔑
오늘 근로현황 및 업무 완료 현황 조회
인원별 근무·근태 상태와 누적 근무시간 조회
UserProfile 및 근무·근태 상태 코드 추가

## 4. 기타 💬
지각은 예정 시작 시각 10분 초과 출근부터 적용됩니다
lateMinutes는 예정 시작 시각부터 계산합니다