### PR TITLE
feat: 어드민 시스템 생성년도 조회 API 구현

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/organization/entity/Organization.java
+++ b/src/main/java/com/better/CommuteMate/domain/organization/entity/Organization.java
@@ -5,10 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "organization")
@@ -23,11 +26,19 @@ public class Organization {
     @Column(length = 30, nullable = false, unique = true)
     private String name;
 
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
     public Organization(String name) {
         this.name = name;
     }
 
     public void updateName(String name) {
         this.name = name;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminSystemService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminSystemService.java
@@ -1,0 +1,36 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.organization.entity.Organization;
+import com.better.CommuteMate.domain.organization.repository.OrganizationRepository;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.OrganizationErrorCode;
+import com.better.CommuteMate.schedule.controller.admin.dtos.SystemCreatedYearResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AdminSystemService {
+
+    private final OrganizationRepository organizationRepository;
+
+    @Transactional(readOnly = true)
+    public SystemCreatedYearResponse getCreatedYear(Long organizationId) {
+        Organization organization = organizationRepository.findById(organizationId)
+                .orElseThrow(() -> CustomException.of(OrganizationErrorCode.ORGANIZATION_NOT_FOUND));
+
+        LocalDateTime createdAt = organization.getCreatedAt();
+        int year;
+        if (createdAt != null) {
+            year = createdAt.getYear();
+        } else {
+            // TODO: created_at null 시 처리 확인 필요
+            year = LocalDateTime.now().getYear();
+        }
+
+        return new SystemCreatedYearResponse(year);
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminSystemController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminSystemController.java
@@ -1,0 +1,70 @@
+package com.better.CommuteMate.schedule.controller.admin;
+
+import com.better.CommuteMate.auth.application.CustomUserDetails;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.schedule.application.AdminSystemService;
+import com.better.CommuteMate.schedule.controller.admin.dtos.SystemCreatedYearResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "관리자 시스템", description = "관리자용 시스템 정보 조회 API")
+@SecurityRequirement(name = "JWT")
+@RestController
+@RequestMapping("/api/v1/admin/system")
+@RequiredArgsConstructor
+public class AdminSystemController {
+
+    private final AdminSystemService adminSystemService;
+
+    @GetMapping("/created-year")
+    @Operation(
+            summary = "시스템 생성 연도 조회",
+            description = "로그인한 사용자가 소속된 조직의 생성 연도를 조회합니다. " +
+                    "관리자 화면의 연도 선택 UI에서 선택 가능한 최소 연도(하한선)로 사용됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "시스템 생성 연도 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "조회 성공",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "message": "시스템 생성 연도를 조회했습니다.",
+                                              "details": {
+                                                "createdYear": 2024
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
+    })
+    public ResponseEntity<Response> getCreatedYear(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        SystemCreatedYearResponse details = adminSystemService.getCreatedYear(
+                userDetails.getUser().getOrganizationId()
+        );
+        return ResponseEntity.ok(Response.of(
+                true,
+                "시스템 생성 연도를 조회했습니다.",
+                details
+        ));
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/SystemCreatedYearResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/SystemCreatedYearResponse.java
@@ -1,0 +1,23 @@
+package com.better.CommuteMate.schedule.controller.admin.dtos;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public class SystemCreatedYearResponse extends ResponseDetail {
+
+    @Schema(description = "시스템(조직) 생성 연도", example = "2024")
+    public final int createdYear;
+
+    public SystemCreatedYearResponse(int createdYear) {
+        this.createdYear = createdYear;
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+}


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝

- 로그인한 사용자의 소속 조직 생성 연도를 조회 후 반환

## 2. 관련 이슈 🔗

https://github.com/konkuk-icteam-student/CommuteMate-backend/issues/116

## 3. 주요 변경 사항 🔑

- `GET /api/v1/admin/system/created-year` 엔드포인트 추가
- 로그인 사용자의 소속 조직(`organization.created_at`) 기준으로 생성 연도 반환
- 인증 필요(401), 관리자 권한 체크는 없음 (로그인 시 학생/관리자 공통 조회 가능)
- `Organization` 엔티티가 공통 `BaseTimeEntity`를 상속하도록 수정하여 `created_at`이 자동 채워지도록 처리 (기존에는 Auditing 미적용으로 `created_at`이 저장되지 않던 문제 해결)
- `AdminSystemController`, `AdminSystemService`, `SystemCreatedYearResponse` 신규 생성
- Swagger(springdoc) 명세 함께 작성, `@SecurityRequirement(name = "JWT")` 적용 (401 자동 주입)

## 4. 기타 💬

- `Organization`은 공용 도메인이라 이번 변경은 `created_at` 자동 채움에 필요한 `BaseTimeEntity` 상속만 최소로 적용했습니다. ERD상 존재하나 엔티티에 없는 나머지 컬럼(`description`, `created_by`, `updated_by` 등)은 이번 범위에서 다루지 않았습니다.
- **기존에 이미 저장된 organization 레코드는 `created_at`이 null이므로, 이 API가 해당 조직에 대해서는 폴백값(현재 연도)을 반환합니다.** Auditing은 이후 저장되는 레코드부터 적용되어 소급되지 않으므로, 기존 레코드의 `created_at` 백필(backfill)이 별도로 필요합니다. (organization 담당자/팀 확인 요망)
- `created_at`이 null인 경우 현재 연도로 폴백하도록 처리하고 관련 TODO 주석을 남겼습니다.
