### PR TITLE
fix: 담당자 조회 시 searchName null 처리 오류 수정

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/category/repository/ManagerCategoryRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/category/repository/ManagerCategoryRepository.java
@@ -25,8 +25,7 @@ public interface ManagerCategoryRepository extends JpaRepository<ManagerCategory
       and (:organization is null or mc.manager.organization = :organization)
       and (:favoriteOnly = false or mc.favorite = true)
       and (
-          :searchName is null\s
-          or length(trim(:searchName)) = 0
+          :searchName = ''
           or lower(mc.manager.name) like lower(concat('%', :searchName, '%'))
       )
     """)

--- a/src/main/java/com/better/CommuteMate/manager/application/ManagerService.java
+++ b/src/main/java/com/better/CommuteMate/manager/application/ManagerService.java
@@ -64,7 +64,9 @@ public class ManagerService {
                     .orElseThrow(() -> new CustomException(OrganizationErrorCode.ORGANIZATION_NOT_FOUND));
         }
 
-        List<ManagerCategory> managerCategories = managerCategoryRepository.getManagers(categoryId, organization, favoriteOnly, searchName);
+        String normalizedSearchName = (searchName == null) ? "" : searchName.trim();
+
+        List<ManagerCategory> managerCategories = managerCategoryRepository.getManagers(categoryId, organization, favoriteOnly, normalizedSearchName);
 
         List<GetManagerListResponse> result = managerCategories.stream()
                 .map(GetManagerListResponse::new)


### PR DESCRIPTION
## 변경 사항

* 담당자 목록 조회 시 `searchName`이 `null`인 경우 빈 문자열로 정규화하도록 수정
* 검색어 앞뒤 공백을 제거하도록 처리
* Repository 쿼리에서 `trim(:searchName)` 및 null 체크 로직 제거
* 정규화된 검색어가 빈 문자열인 경우 이름 필터를 적용하지 않도록 수정

## 문제 원인

담당자 목록 조회 시 `searchName`이 `null`로 전달되면 Repository의 `trim(:searchName)` 처리 과정에서 PostgreSQL이 파라미터 타입을 잘못 해석하여 `btrim(bytea)` 오류가 발생했습니다.

## 수정 내용

Service에서 `searchName`을 정규화하여 Repository에는 항상 null이 아닌 문자열이 전달되도록 변경했습니다.

* `null` → `""`
* 공백 문자열 → `""`
* 일반 검색어 → 앞뒤 공백 제거 후 전달

이에 따라 Repository에서는 별도의 null/trim 처리를 제거하고 이름 검색 조건만 수행하도록 단순화했습니다.
