### PR TITLE
fix: PK/FK 타입 Long 통일 및 근로 시간표 조회 이슈 수정

### DIFF
--- a/src/main/java/com/better/CommuteMate/attendance/controller/dto/AttendanceHistoryResponse.java
+++ b/src/main/java/com/better/CommuteMate/attendance/controller/dto/AttendanceHistoryResponse.java
@@ -17,7 +17,7 @@ public class AttendanceHistoryResponse {
     private Long attendanceId;
     private LocalDateTime checkTime;
     private CodeType checkType;
-    private String scheduleId;
+    private Long scheduleId;
     private LocalTime scheduleStartTime;
     private LocalTime scheduleEndTime;
 }

--- a/src/main/java/com/better/CommuteMate/domain/notification/entity/Notification.java
+++ b/src/main/java/com/better/CommuteMate/domain/notification/entity/Notification.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @Table(name = "notification", indexes = {
@@ -20,8 +19,9 @@ import java.util.UUID;
 public class Notification {
 
     @Id
-    @Column(name = "notification_id", nullable = false, length = 36)
-    private String notificationId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id", nullable = false)
+    private Long notificationId;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
@@ -44,9 +44,6 @@ public class Notification {
 
     @PrePersist
     protected void onCreate() {
-        if (notificationId == null) {
-            notificationId = UUID.randomUUID().toString();
-        }
         if (createdAt == null) {
             createdAt = LocalDateTime.now();
         }

--- a/src/main/java/com/better/CommuteMate/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/notification/repository/NotificationRepository.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
-public interface NotificationRepository extends JpaRepository<Notification, String> {
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
 

--- a/src/main/java/com/better/CommuteMate/domain/schedule/entity/WorkSchedule.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/entity/WorkSchedule.java
@@ -9,7 +9,6 @@ import lombok.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.UUID;
 
 @Entity
 @Table(name = "work_schedule")
@@ -20,8 +19,9 @@ import java.util.UUID;
 public class WorkSchedule {
 
     @Id
-    @Column(name = "schedule_id", nullable = false, length = 36)
-    private String scheduleId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "schedule_id", nullable = false)
+    private Long scheduleId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -127,10 +127,6 @@ public class WorkSchedule {
 
     @PrePersist
     protected void onCreate() {
-        if (this.scheduleId == null) {
-            this.scheduleId = UUID.randomUUID().toString();
-        }
-
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/better/CommuteMate/domain/schedule/entity/WorkScheduleSetting.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/entity/WorkScheduleSetting.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @Table(
@@ -23,11 +22,12 @@ import java.util.UUID;
 public class WorkScheduleSetting {
 
     @Id
-    @Column(name = "setting_id", nullable = false, length = 36)
-    private String settingId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "setting_id", nullable = false)
+    private Long settingId;
 
-    @Column(name = "organization_id", nullable = false, length = 36)
-    private String organizationId;
+    @Column(name = "organization_id", nullable = false)
+    private Long organizationId;
 
     @Column(name = "year", nullable = false)
     private Integer year;
@@ -162,10 +162,6 @@ public class WorkScheduleSetting {
 
     @PrePersist
     protected void onCreate() {
-        if (this.settingId == null) {
-            this.settingId = UUID.randomUUID().toString();
-        }
-
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkScheduleSettingRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkScheduleSettingRepository.java
@@ -11,19 +11,19 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 @Repository
-public interface WorkScheduleSettingRepository extends JpaRepository<WorkScheduleSetting, String> {
+public interface WorkScheduleSettingRepository extends JpaRepository<WorkScheduleSetting, Long> {
 
     /**
      * 특정 조직의 특정 연/월 근무 일정 설정을 조회
      */
     Optional<WorkScheduleSetting> findByOrganizationIdAndYearAndMonth(
-            String organizationId,
+            Long organizationId,
             Integer year,
             Integer month
     );
 
     boolean existsByOrganizationIdAndYearAndMonth(
-            String organizationId,
+            Long organizationId,
             Integer year,
             Integer month
     );
@@ -38,7 +38,7 @@ public interface WorkScheduleSettingRepository extends JpaRepository<WorkSchedul
               and setting.month = :month
             """)
     Optional<WorkScheduleSetting> findForUpdate(
-            @Param("organizationId") String organizationId,
+            @Param("organizationId") Long organizationId,
             @Param("year") Integer year,
             @Param("month") Integer month
     );

--- a/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/schedule/repository/WorkSchedulesRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface WorkSchedulesRepository extends JpaRepository<WorkSchedule, String> {
+public interface WorkSchedulesRepository extends JpaRepository<WorkSchedule, Long> {
 
     /**
      * 특정 날짜의 근무 일정 목록을 조회

--- a/src/main/java/com/better/CommuteMate/domain/workattendance/repository/WorkAttendanceRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/workattendance/repository/WorkAttendanceRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Repository
 public interface WorkAttendanceRepository extends JpaRepository<WorkAttendance, Integer> {
     List<WorkAttendance> findByUser_UserIdAndCheckTime(Long userId, LocalDateTime checkTime);
-    List<WorkAttendance> findBySchedule_ScheduleId(String scheduleId);
+    List<WorkAttendance> findBySchedule_ScheduleId(Long scheduleId);
     List<WorkAttendance> findByUser_UserIdAndCheckTimeBetween(Long userId, LocalDateTime start, LocalDateTime end);
     List<WorkAttendance> findAllByScheduleIn(List<WorkSchedule> schedules);
 }

--- a/src/main/java/com/better/CommuteMate/domain/workplace/entity/Workplace.java
+++ b/src/main/java/com/better/CommuteMate/domain/workplace/entity/Workplace.java
@@ -5,7 +5,6 @@ import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @Table(name = "workplace")
@@ -16,11 +15,12 @@ import java.util.UUID;
 public class Workplace {
 
     @Id
-    @Column(name = "workplace_id", nullable = false, length = 36)
-    private String workplaceId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "workplace_id", nullable = false)
+    private Long workplaceId;
 
-    @Column(name = "organization_id", nullable = false, length = 36)
-    private String organizationId;
+    @Column(name = "organization_id", nullable = false)
+    private Long organizationId;
 
     @Column(name = "name", nullable = false, length = 100)
     private String name;
@@ -90,10 +90,6 @@ public class Workplace {
 
     @PrePersist
     protected void onCreate() {
-        if (this.workplaceId == null) {
-            this.workplaceId = UUID.randomUUID().toString();
-        }
-
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/better/CommuteMate/domain/workplace/repository/WorkplaceRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/workplace/repository/WorkplaceRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface WorkplaceRepository extends JpaRepository<Workplace, String> {
+public interface WorkplaceRepository extends JpaRepository<Workplace, Long> {
 
-    Optional<Workplace> findFirstByOrganizationId(String organizationId);
+    Optional<Workplace> findFirstByOrganizationId(Long organizationId);
 }

--- a/src/main/java/com/better/CommuteMate/home/application/AdminHomeService.java
+++ b/src/main/java/com/better/CommuteMate/home/application/AdminHomeService.java
@@ -45,7 +45,7 @@ public class AdminHomeService {
         List<WorkAttendance> attendances = schedules.isEmpty()
                 ? List.of()
                 : attendanceRepository.findAllByScheduleIn(schedules);
-        Map<String, List<WorkAttendance>> attendanceBySchedule = attendances.stream()
+        Map<Long, List<WorkAttendance>> attendanceBySchedule = attendances.stream()
                 .collect(Collectors.groupingBy(
                         attendance -> attendance.getSchedule().getScheduleId()
                 ));

--- a/src/main/java/com/better/CommuteMate/home/application/AdminUserAttendanceService.java
+++ b/src/main/java/com/better/CommuteMate/home/application/AdminUserAttendanceService.java
@@ -83,7 +83,7 @@ public class AdminUserAttendanceService {
         List<WorkAttendance> attendances = schedules.isEmpty()
                 ? List.of()
                 : attendanceRepository.findAllByScheduleIn(schedules);
-        Map<String, List<WorkAttendance>> attendancesBySchedule = attendances.stream()
+        Map<Long, List<WorkAttendance>> attendancesBySchedule = attendances.stream()
                 .collect(Collectors.groupingBy(
                         attendance -> attendance.getSchedule().getScheduleId()
                 ));
@@ -91,7 +91,7 @@ public class AdminUserAttendanceService {
                 .collect(Collectors.groupingBy(schedule -> schedule.getUser().getUserId()));
         Optional<WorkScheduleSetting> setting =
                 settingRepository.findByOrganizationIdAndYearAndMonth(
-                        String.valueOf(organizationId), date.getYear(), date.getMonthValue()
+                        organizationId, date.getYear(), date.getMonthValue()
                 );
         int weeklyLimit = setting.map(WorkScheduleSetting::getWeeklyMaxMinutes).orElse(0);
         int monthlyLimit = setting.map(WorkScheduleSetting::getMonthlyMaxMinutes).orElse(0);
@@ -175,7 +175,7 @@ public class AdminUserAttendanceService {
 
     private Status determineStatus(
             List<WorkSchedule> schedules,
-            Map<String, List<WorkAttendance>> attendancesBySchedule,
+            Map<Long, List<WorkAttendance>> attendancesBySchedule,
             LocalDateTime referenceTime
     ) {
         if (schedules.isEmpty()) {
@@ -243,7 +243,7 @@ public class AdminUserAttendanceService {
 
     private LateSummary calculateLateSummary(
             List<WorkSchedule> schedules,
-            Map<String, List<WorkAttendance>> attendancesBySchedule
+            Map<Long, List<WorkAttendance>> attendancesBySchedule
     ) {
         int count = 0;
         int minutes = 0;
@@ -264,7 +264,7 @@ public class AdminUserAttendanceService {
 
     private int calculateWorkedMinutes(
             List<WorkSchedule> schedules,
-            Map<String, List<WorkAttendance>> attendancesBySchedule,
+            Map<Long, List<WorkAttendance>> attendancesBySchedule,
             Predicate<WorkSchedule> include,
             LocalDateTime referenceTime
     ) {

--- a/src/main/java/com/better/CommuteMate/home/controller/dto/HomeAttendanceStatusResponse.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/dto/HomeAttendanceStatusResponse.java
@@ -13,13 +13,13 @@ import java.time.LocalTime;
 public class HomeAttendanceStatusResponse extends ResponseDetail {
     private AttendanceStatus status;
     private String message;
-    private String currentScheduleId;
+    private Long currentScheduleId;
     private LocalTime scheduleStartTime;
     private LocalTime scheduleEndTime;
 
     @Builder
     public HomeAttendanceStatusResponse(AttendanceStatus status, String message,
-                                        String currentScheduleId,
+                                        Long currentScheduleId,
                                         LocalTime scheduleStartTime,
                                         LocalTime scheduleEndTime) {
         super();

--- a/src/main/java/com/better/CommuteMate/notification/controller/dtos/NotificationListResponse.java
+++ b/src/main/java/com/better/CommuteMate/notification/controller/dtos/NotificationListResponse.java
@@ -24,8 +24,8 @@ public class NotificationListResponse extends ResponseDetail {
     }
 
     public record NotificationItem(
-            @Schema(description = "알림 ID (UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
-            String notificationId,
+            @Schema(description = "알림 ID", example = "1")
+            Long notificationId,
 
             @Schema(description = "알림 유형 코드 (NT01: 근무 변경 요청 승인, NT02: 근무 변경 요청 거절, NT03: 근무 신청 시작)", example = "NT02")
             String typeCode,

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkChangeRequestProcessService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkChangeRequestProcessService.java
@@ -104,7 +104,7 @@ public class AdminWorkChangeRequestProcessService {
         scheduleRepository.flush();
 
         Workplace workplace = workplaceRepository
-                .findFirstByOrganizationId(String.valueOf(organizationId))
+                .findFirstByOrganizationId(organizationId)
                 .orElseThrow(() -> CustomException.of(ScheduleErrorCode.SCHEDULE_FAILURE));
 
         for (WorkChangeRequestItem item : items) {
@@ -113,7 +113,7 @@ public class AdminWorkChangeRequestProcessService {
             }
             YearMonth month = YearMonth.from(item.getDate());
             WorkScheduleSetting setting = settingRepository.findForUpdate(
-                            String.valueOf(organizationId),
+                            organizationId,
                             month.getYear(),
                             month.getMonthValue()
                     )

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQueryService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQueryService.java
@@ -35,7 +35,7 @@ public class AdminWorkScheduleQueryService {
     private final WorkUnavailableTimeRepository unavailableTimeRepository;
 
     public AdminScheduleRangeResponse getSchedules(
-            String organizationId,
+            Long organizationId,
             String startDateValue,
             String endDateValue,
             String userName
@@ -105,7 +105,7 @@ public class AdminWorkScheduleQueryService {
         );
     }
 
-    private boolean hasSetting(String organizationId, YearMonth yearMonth) {
+    private boolean hasSetting(Long organizationId, YearMonth yearMonth) {
         return settingRepository.existsByOrganizationIdAndYearAndMonth(
                 organizationId,
                 yearMonth.getYear(),

--- a/src/main/java/com/better/CommuteMate/schedule/application/MonthlyScheduleSettingService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/MonthlyScheduleSettingService.java
@@ -38,7 +38,7 @@ public class MonthlyScheduleSettingService {
 
     @Transactional
     public SaveScheduleSettingResponse save(
-            String organizationId,
+            Long organizationId,
             int year,
             int month,
             SaveScheduleSettingRequest request,
@@ -104,7 +104,7 @@ public class MonthlyScheduleSettingService {
     }
 
     private WorkScheduleSetting newSetting(
-            String organizationId,
+            Long organizationId,
             int year,
             int month,
             SaveScheduleSettingRequest request,

--- a/src/main/java/com/better/CommuteMate/schedule/application/ScheduleService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/ScheduleService.java
@@ -75,7 +75,7 @@ public class ScheduleService {
     private static final List<CodeType> ACTIVE_STATUSES = List.of(CodeType.WS01, CodeType.WS02);
     private static final int DEFAULT_SETTING_MAX_CONCURRENT = 4;
     private static final LocalTime WORK_START_TIME = LocalTime.of(9, 0);
-    private static final LocalTime WORK_END_TIME = LocalTime.of(17, 30);
+    private static final LocalTime WORK_END_TIME = LocalTime.of(18, 0);
     private static final int SLOT_MINUTES = 30;
 
     /**

--- a/src/main/java/com/better/CommuteMate/schedule/application/ScheduleService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/ScheduleService.java
@@ -284,7 +284,7 @@ public class ScheduleService {
         }
 
         WorkScheduleSetting setting = workScheduleSettingService.getRequiredSetting(
-                String.valueOf(user.getOrganizationId()),
+                user.getOrganizationId(),
                 slot.date().getYear(),
                 slot.date().getMonthValue()
         );
@@ -328,7 +328,7 @@ public class ScheduleService {
      * User 엔티티 구조에 맞게 이 부분만 수정하면 됩니다.
      */
     private Workplace resolveWorkplace(User user) {
-        return workplaceRepository.findFirstByOrganizationId(String.valueOf(user.getOrganizationId()))
+        return workplaceRepository.findFirstByOrganizationId(user.getOrganizationId())
                 .orElseThrow(() -> CustomException.of(ScheduleErrorCode.SCHEDULE_FAILURE));
     }
 
@@ -436,7 +436,7 @@ public class ScheduleService {
     @Transactional(readOnly = true)
     public WorkScheduleResponse getWorkSchedule(
             Long userId,
-            String scheduleId
+            Long scheduleId
     ) {
         WorkSchedule schedule = workSchedulesRepository.findById(scheduleId)
                 .orElseThrow(() -> CustomException.of(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
@@ -481,7 +481,7 @@ public class ScheduleService {
 
     @Transactional(readOnly = true)
     public WorkScheduleMonthlyLimitResponse getMonthlyLimit(
-            String organizationId,
+            Long organizationId,
             Integer year,
             Integer month
     ) {
@@ -512,7 +512,7 @@ public class ScheduleService {
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));
 
-        validateMonthlyLimitForEdit(userId, String.valueOf(user.getOrganizationId()), addSlots, deleteSlots);
+        validateMonthlyLimitForEdit(userId, user.getOrganizationId(), addSlots, deleteSlots);
 
         WorkChangeRequest changeRequest = WorkChangeRequest.builder()
                 .user(user)
@@ -558,7 +558,7 @@ public class ScheduleService {
 
     private void validateMonthlyLimitForEdit(
             Long userId,
-            String organizationId,
+            Long organizationId,
             List<WorkScheduleEditRequest.Slot> addSlots,
             List<WorkScheduleEditRequest.Slot> deleteSlots
     ) {
@@ -599,7 +599,7 @@ public class ScheduleService {
     @Transactional(readOnly = true)
     public WorkMonthlyScheduleResponse getMonthlyScheduleView(
             Long userId,
-            String organizationId,
+            Long organizationId,
             Integer year,
             Integer month
     ) {
@@ -625,7 +625,7 @@ public class ScheduleService {
     @Transactional(readOnly = true)
     public WorkScheduleSummaryResponse getScheduleSummary(
             Long userId,
-            String organizationId,
+            Long organizationId,
             LocalDate startDate,
             LocalDate endDate
     ) {
@@ -677,7 +677,7 @@ public class ScheduleService {
     @Transactional(readOnly = true)
     public WorkScheduleRangeResponse getScheduleRangeView(
             Long userId,
-            String organizationId,
+            Long organizationId,
             LocalDate startDate,
             LocalDate endDate
     ) {

--- a/src/main/java/com/better/CommuteMate/schedule/application/WorkScheduleSettingService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/WorkScheduleSettingService.java
@@ -28,7 +28,7 @@ public class WorkScheduleSettingService {
      * 특정 조직의 특정 연/월 근무 일정 설정을 조회합니다.
      */
     public Optional<WorkScheduleSetting> getSetting(
-            String organizationId,
+            Long organizationId,
             Integer year,
             Integer month
     ) {
@@ -44,7 +44,7 @@ public class WorkScheduleSettingService {
      * 설정이 없으면 예외를 발생시킵니다.
      */
     public WorkScheduleSetting getRequiredSetting(
-            String organizationId,
+            Long organizationId,
             Integer year,
             Integer month
     ) {
@@ -63,7 +63,7 @@ public class WorkScheduleSettingService {
      * 특정 시간이 신청 기간 내인지 확인합니다.
      */
     public boolean isCurrentlyInApplyTerm(
-            String organizationId,
+            Long organizationId,
             LocalDateTime targetTime
     ) {
         WorkScheduleSetting setting = getRequiredSetting(
@@ -80,7 +80,7 @@ public class WorkScheduleSettingService {
      */
     @Transactional
     public WorkScheduleSetting setApplyTerm(
-            String organizationId,
+            Long organizationId,
             Integer year,
             Integer month,
             LocalDateTime applyStartAt,
@@ -133,7 +133,7 @@ public class WorkScheduleSettingService {
      */
     @Transactional
     public WorkScheduleSetting setWorkRule(
-            String organizationId,
+            Long organizationId,
             Integer year,
             Integer month,
             Integer maxConcurrentWorkers,

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminScheduleController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "관리자 근무 일정 관리", description = "관리자용 근무 일정 설정 API")
-@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/admin")
 @RequiredArgsConstructor
@@ -139,6 +138,7 @@ public class AdminScheduleController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
             @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
     })
+    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> saveScheduleSetting(
             @Parameter(description = "설정 연도", example = "2026", required = true)
             @PathVariable int year,
@@ -147,7 +147,7 @@ public class AdminScheduleController {
             @Valid @RequestBody SaveScheduleSettingRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        String organizationId = String.valueOf(userDetails.getUser().getOrganizationId());
+        Long organizationId = userDetails.getUser().getOrganizationId();
         String adminId = String.valueOf(userDetails.getUserId());
         SaveScheduleSettingResponse result = monthlyScheduleSettingService.save(
                 organizationId, year, month, request, adminId

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminWorkScheduleController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "관리자 근로시간표", description = "관리자용 근로시간표 조회 API")
-@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/admin/work-schedules")
 @RequiredArgsConstructor
@@ -105,6 +104,7 @@ public class AdminWorkScheduleController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
             @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
     })
+    @SecurityRequirement(name = "JWT")
     public ResponseEntity<Response> getSchedules(
             @Parameter(description = "조회 시작일", example = "2026-04-15", required = true)
             @RequestParam(required = false) String startDate,
@@ -114,7 +114,7 @@ public class AdminWorkScheduleController {
             @RequestParam(required = false) String userName,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        String organizationId = String.valueOf(userDetails.getUser().getOrganizationId());
+        Long organizationId = userDetails.getUser().getOrganizationId();
         AdminScheduleRangeResponse details = queryService.getSchedules(
                 organizationId, startDate, endDate, userName
         );

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/ApplyRequestResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/ApplyRequestResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record ApplyRequestResponse(
-        String scheduleId,
+        Long scheduleId,
         Long userId,
         String userName,
         LocalDate date,

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/ProcessWorkChangeResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/ProcessWorkChangeResponse.java
@@ -43,7 +43,7 @@ public class ProcessWorkChangeResponse extends ResponseDetail {
     }
 
     public record ScheduleResult(
-            String scheduleId,
+            Long scheduleId,
             @JsonFormat(pattern = "yyyy-MM-dd") LocalDate date,
             @JsonFormat(pattern = "HH:mm") LocalTime start,
             @JsonFormat(pattern = "HH:mm") LocalTime end,

--- a/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -34,7 +33,6 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 
 @Tag(name = "사용자 근무 일정", description = "사용자 근무 일정 신청 및 조회 API")
-@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/work-schedules")
 @RequiredArgsConstructor
@@ -180,7 +178,7 @@ public class WorkScheduleController {
     @Operation(summary = "특정 근무 일정 조회", description = "ID로 특정 근무 일정을 조회합니다.")
     @GetMapping("/{scheduleId}")
     public ResponseEntity<Response> getWorkSchedule(
-            @PathVariable String scheduleId,
+            @PathVariable Long scheduleId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUser().getUserId();
@@ -227,7 +225,7 @@ public class WorkScheduleController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUser().getUserId();
-        String organizationId = String.valueOf(userDetails.getUser().getOrganizationId());
+        Long organizationId = userDetails.getUser().getOrganizationId();
         WorkScheduleSummaryResponse response =
                 scheduleService.getScheduleSummary(userId, organizationId, startDate, endDate);
         return ResponseEntity.ok(Response.of(true, "근로시간 요약을 조회했습니다.", response));
@@ -297,7 +295,7 @@ public class WorkScheduleController {
             @PathVariable Integer month,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        String organizationId = String.valueOf(userDetails.getUser().getOrganizationId());
+        Long organizationId = userDetails.getUser().getOrganizationId();
         return ResponseEntity.ok(Response.of(
                 true,
                 "월별 스케줄 제한을 조회했습니다.",
@@ -335,7 +333,7 @@ public class WorkScheduleController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUser().getUserId();
-        String organizationId = String.valueOf(userDetails.getUser().getOrganizationId());
+        Long organizationId = userDetails.getUser().getOrganizationId();
 
         WorkMonthlyScheduleResponse response =
                 scheduleService.getMonthlyScheduleView(userId, organizationId, year, month);
@@ -377,7 +375,7 @@ public class WorkScheduleController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUser().getUserId();
-        String organizationId = String.valueOf(userDetails.getUser().getOrganizationId());
+        Long organizationId = userDetails.getUser().getOrganizationId();
 
         WorkScheduleRangeResponse response =
                 scheduleService.getScheduleRangeView(userId, organizationId, startDate, endDate);

--- a/src/main/java/com/better/CommuteMate/schedule/controller/schedule/dtos/WorkScheduleHistoryResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/schedule/dtos/WorkScheduleHistoryResponse.java
@@ -10,18 +10,18 @@ import java.time.LocalDateTime;
 
 @Getter
 public class WorkScheduleHistoryResponse extends ResponseDetail {
-    private final String id;
+    private final Long id;
     private final String userName;
     private final LocalDateTime start;
     private final LocalDateTime end;
     private final CodeType status;
-    
+
     private final LocalDateTime actualStart;
     private final LocalDateTime actualEnd;
     private final Long workDurationMinutes;
 
     @Builder
-    public WorkScheduleHistoryResponse(String id, String userName, LocalDateTime start, LocalDateTime end, CodeType status,
+    public WorkScheduleHistoryResponse(Long id, String userName, LocalDateTime start, LocalDateTime end, CodeType status,
                                        LocalDateTime actualStart, LocalDateTime actualEnd, Long workDurationMinutes) {
         this.id = id;
         this.userName = userName;

--- a/src/main/java/com/better/CommuteMate/schedule/controller/schedule/dtos/WorkScheduleResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/schedule/dtos/WorkScheduleResponse.java
@@ -10,13 +10,13 @@ import java.time.LocalDateTime;
 @Getter
 public class WorkScheduleResponse extends ResponseDetail {
 
-    private final String id;
+    private final Long id;
     private final LocalDateTime start;
     private final LocalDateTime end;
     private final CodeType status;
 
     public WorkScheduleResponse(
-            String id,
+            Long id,
             LocalDateTime start,
             LocalDateTime end,
             CodeType status


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
- 프로젝트 전체 엔티티의 PK/FK 타입을 Long(bigint)으로 통일 및 근로 시간표 조회에서 발견된 이슈들을 수정
- 기존에 일부 엔티티만 String(UUID) PK를 사용해 FK 타입이 어긋나면서 스키마 생성이 실패하던 문제가 있었고, 이를 해소하는 과정에서 슬롯 조회 관련 버그도 함께 수정했습니다.

## 2. 관련 이슈 🔗
https://github.com/konkuk-icteam-student/CommuteMate-backend/issues/125

## 3. 주요 변경 사항 🔑
**PK/FK 타입 통일**
- `WorkSchedule`, `WorkScheduleSetting`, `Workplace`, `Notification`의 PK를 String(UUID) → Long(IDENTITY)으로 변경
- `Workplace`, `WorkScheduleSetting`의 `organizationId`를 String(36) → Long으로 수정 (참조 대상인 `Organization.id`가 Long이라 기존에 타입이 어긋나 있던 부분)
- 관련 DTO·서비스·레포지토리·컨트롤러의 ID 타입 및 Swagger example 값 일괄 정리
- 이로써 프로젝트 전체 엔티티 PK가 Long으로 통일되었고, FK↔PK 타입 불일치가 모두 해소됨

**신청 불가 일자가 EMPTY로 응답되던 문제 수정**
- unavailable 매칭 방식을 30분 슬롯 키(SlotKey) 동등 비교에서 범위 겹침 비교로 변경
- 불가 일자는 하루 전체 범위로 저장되어 슬롯 키 경계가 어긋나 매칭에서 누락되었으나, 겹침 비교(`slotStart < uEnd && slotEnd > uStart`)로 불가 일자·불가 시간대 모두 정상 판정되도록 수정
- `expandToSlots`의 자정 wrap-around 무한 루프 방어 로직 추가

**빈 슬롯(EMPTY) 누락 문제 수정**
- 기존에는 신청 이력이 있거나 불가 처리된 슬롯만 응답에 포함되어, 프론트가 시간표 그리드를 그릴 때 빈 칸을 채울 데이터가 없었음
- 근무 가능 시간대 전체를 30분 단위로 생성한 뒤 각 슬롯 상태를 판정하는 방식으로 변경하여, 아무도 신청하지 않은 슬롯도 `EMPTY`로 응답에 포함

**근무 가능 시간대 확장**
- 09:00-17:30 → 09:00-18:00


## 4. 기타 💬
