### PR TITLE
[FIX] 근무변경신청조회 api 쿼리 수정

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/workchangerequest/repository/WorkChangeRequestRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/workchangerequest/repository/WorkChangeRequestRepository.java
@@ -84,33 +84,37 @@ public interface WorkChangeRequestRepository extends JpaRepository<WorkChangeReq
             @Param("statusCode") CodeType statusCode
     );
 
-    @Query(
-            value = """
-                    select request
-                    from WorkChangeRequest request
-                    where request.user.userId = :userId
-                      and (:startDate is null or exists (
-                        select item.itemId
-                        from WorkChangeRequestItem item
-                        where item.request = request
-                          and item.date between :startDate and :endDate
-                      ))
-                      and (:statusCode is null or request.statusCode = :statusCode)
-                    """,
-            countQuery = """
-                    select count(request.requestId)
-                    from WorkChangeRequest request
-                    where request.user.userId = :userId
-                      and (:startDate is null or exists (
-                        select item.itemId
-                        from WorkChangeRequestItem item
-                        where item.request = request
-                          and item.date between :startDate and :endDate
-                      ))
-                      and (:statusCode is null or request.statusCode = :statusCode)
-                    """
-    )
-    Page<WorkChangeRequest> findUserRequests(
+    @Query("""
+            select request
+            from WorkChangeRequest request
+            where request.user.userId = :userId
+              and exists (
+                select item.itemId
+                from WorkChangeRequestItem item
+                where item.request = request
+                  and item.date between :startDate and :endDate
+              )
+            """)
+    Page<WorkChangeRequest> findUserRequestsByMonth(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            Pageable pageable
+    );
+
+    @Query("""
+            select request
+            from WorkChangeRequest request
+            where request.user.userId = :userId
+              and exists (
+                select item.itemId
+                from WorkChangeRequestItem item
+                where item.request = request
+                  and item.date between :startDate and :endDate
+              )
+              and request.statusCode = :statusCode
+            """)
+    Page<WorkChangeRequest> findUserRequestsByMonthAndStatus(
             @Param("userId") Long userId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate,
@@ -118,22 +122,49 @@ public interface WorkChangeRequestRepository extends JpaRepository<WorkChangeReq
             Pageable pageable
     );
 
+    Page<WorkChangeRequest> findByUser_UserId(Long userId, Pageable pageable);
+
+    Page<WorkChangeRequest> findByUser_UserIdAndStatusCode(
+            Long userId, CodeType statusCode, Pageable pageable
+    );
+
     @Query("""
             select count(request.requestId)
             from WorkChangeRequest request
             where request.user.userId = :userId
-              and (:startDate is null or exists (
+              and exists (
                 select item.itemId
                 from WorkChangeRequestItem item
                 where item.request = request
                   and item.date between :startDate and :endDate
-              ))
-              and (:statusCode is null or request.statusCode = :statusCode)
+              )
             """)
-    long countUserRequests(
+    long countUserRequestsByMonth(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
+    @Query("""
+            select count(request.requestId)
+            from WorkChangeRequest request
+            where request.user.userId = :userId
+              and exists (
+                select item.itemId
+                from WorkChangeRequestItem item
+                where item.request = request
+                  and item.date between :startDate and :endDate
+              )
+              and request.statusCode = :statusCode
+            """)
+    long countUserRequestsByMonthAndStatus(
             @Param("userId") Long userId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate,
             @Param("statusCode") CodeType statusCode
     );
+
+    long countByUser_UserId(Long userId);
+
+    long countByUser_UserIdAndStatusCode(Long userId, CodeType statusCode);
 }

--- a/src/main/java/com/better/CommuteMate/schedule/application/WorkChangeRequestHistoryService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/WorkChangeRequestHistoryService.java
@@ -56,7 +56,7 @@ public class WorkChangeRequestHistoryService {
         LocalDate endDate = targetMonth != null ? targetMonth.atEndOfMonth() : null;
 
         PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<WorkChangeRequest> requestPage = requestRepository.findUserRequests(
+        Page<WorkChangeRequest> requestPage = findUserRequests(
                 userId, startDate, endDate, statusFilter.code, pageable
         );
 
@@ -128,7 +128,35 @@ public class WorkChangeRequestHistoryService {
     }
 
     private long countUser(Long userId, LocalDate startDate, LocalDate endDate, CodeType statusCode) {
-        return requestRepository.countUserRequests(userId, startDate, endDate, statusCode);
+        if (startDate != null) {
+            return statusCode == null
+                    ? requestRepository.countUserRequestsByMonth(userId, startDate, endDate)
+                    : requestRepository.countUserRequestsByMonthAndStatus(
+                            userId, startDate, endDate, statusCode
+                    );
+        }
+        return statusCode == null
+                ? requestRepository.countByUser_UserId(userId)
+                : requestRepository.countByUser_UserIdAndStatusCode(userId, statusCode);
+    }
+
+    private Page<WorkChangeRequest> findUserRequests(
+            Long userId,
+            LocalDate startDate,
+            LocalDate endDate,
+            CodeType statusCode,
+            PageRequest pageable
+    ) {
+        if (startDate != null) {
+            return statusCode == null
+                    ? requestRepository.findUserRequestsByMonth(userId, startDate, endDate, pageable)
+                    : requestRepository.findUserRequestsByMonthAndStatus(
+                            userId, startDate, endDate, statusCode, pageable
+                    );
+        }
+        return statusCode == null
+                ? requestRepository.findByUser_UserId(userId, pageable)
+                : requestRepository.findByUser_UserIdAndStatusCode(userId, statusCode, pageable);
     }
 
     private WorkChangeRequestHistoryResponse.HistoryItem toHistoryItem(

--- a/src/test/java/com/better/CommuteMate/schedule/application/WorkChangeRequestHistoryServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/WorkChangeRequestHistoryServiceTest.java
@@ -1,0 +1,62 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.workchangerequest.repository.WorkChangeRequestItemRepository;
+import com.better.CommuteMate.domain.workchangerequest.repository.WorkChangeRequestRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkChangeRequestHistoryServiceTest {
+
+    @Mock WorkChangeRequestRepository requestRepository;
+    @Mock WorkChangeRequestItemRepository itemRepository;
+
+    private WorkChangeRequestHistoryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkChangeRequestHistoryService(requestRepository, itemRepository);
+    }
+
+    @Test
+    void searchesMonthWithoutBindingNullableStatusForAllFilter() {
+        when(requestRepository.findUserRequestsByMonth(
+                any(), any(), any(), any(Pageable.class)
+        )).thenReturn(Page.empty());
+
+        service.getHistory(1L, 2026, 8, "ALL", 0, 10);
+
+        LocalDate startDate = LocalDate.of(2026, 8, 1);
+        LocalDate endDate = LocalDate.of(2026, 8, 31);
+        verify(requestRepository).findUserRequestsByMonth(
+                eq(1L), eq(startDate), eq(endDate), any(Pageable.class)
+        );
+        verify(requestRepository, never()).findUserRequestsByMonthAndStatus(
+                any(), any(), any(), any(), any(Pageable.class)
+        );
+        verify(requestRepository).countUserRequestsByMonth(1L, startDate, endDate);
+        verify(requestRepository).countUserRequestsByMonthAndStatus(
+                1L, startDate, endDate, CodeType.CS01
+        );
+        verify(requestRepository).countUserRequestsByMonthAndStatus(
+                1L, startDate, endDate, CodeType.CS02
+        );
+        verify(requestRepository).countUserRequestsByMonthAndStatus(
+                1L, startDate, endDate, CodeType.CS03
+        );
+    }
+}


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
근무시간 변경 신청 처리 내역 조회 API에서 발생하던 PostgreSQL 500 오류를 수정했습니다.
기존에는 월 또는 상태 필터의 적용 여부를 nullable 파라미터로 판별했습니다. PostgreSQL이 해당 파라미터의 데이터 타입을 추론하지 못하면서 조회가 실패했으며, 필터 조합별 쿼리를 분리하여 문제를 해결했습니다.
## 2. 관련 이슈 🔗
#127 
## 3. 주요 변경 사항 🔑
### 월별 처리 내역 조회 오류 수정
- nullable 날짜 및 상태 조건 제거
- 월별 전체 신청 내역 조회 지원
- 선택한 월을 기준으로 상태별 조회 지원
- 월 및 상태 필터 조합별 조회 쿼리 분리
- 조회 조건과 상태별 요약 데이터에 동일한 월 범위 적용
## 4. 기타 💬
