### PR TITLE
[FEAT] 관리자 근로설정 조회 api

### DIFF
--- a/src/main/java/com/better/CommuteMate/schedule/application/MonthlyScheduleSettingService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/MonthlyScheduleSettingService.java
@@ -11,6 +11,7 @@ import com.better.CommuteMate.global.exceptions.CustomException;
 import com.better.CommuteMate.global.exceptions.error.ScheduleErrorCode;
 import com.better.CommuteMate.schedule.controller.admin.dtos.SaveScheduleSettingRequest;
 import com.better.CommuteMate.schedule.controller.admin.dtos.SaveScheduleSettingResponse;
+import com.better.CommuteMate.schedule.controller.admin.dtos.ScheduleSettingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,32 @@ public class MonthlyScheduleSettingService {
     private final WorkScheduleSettingRepository settingRepository;
     private final WorkSchedulesRepository scheduleRepository;
     private final WorkUnavailableTimeRepository unavailableTimeRepository;
+
+    @Transactional(readOnly = true)
+    public ScheduleSettingResponse get(Long organizationId, int year, int month) {
+        YearMonth targetMonth;
+        if (year < 1900 || year > 9999) {
+            throw CustomException.of(ScheduleErrorCode.ADMIN_SCHEDULE_QUERY_INVALID);
+        }
+        try {
+            targetMonth = YearMonth.of(year, month);
+        } catch (RuntimeException e) {
+            throw CustomException.of(ScheduleErrorCode.ADMIN_SCHEDULE_QUERY_INVALID);
+        }
+
+        Optional<WorkScheduleSetting> settingOptional = settingRepository
+                .findByOrganizationIdAndYearAndMonth(organizationId, year, month);
+        if (settingOptional.isEmpty()) {
+            return ScheduleSettingResponse.notConfigured(year, month);
+        }
+
+        WorkScheduleSetting setting = settingOptional.get();
+        List<WorkUnavailableTime> unavailableTimes = unavailableTimeRepository
+                .findBySettingAndDateBetween(
+                        setting, targetMonth.atDay(1), targetMonth.atEndOfMonth()
+                );
+        return ScheduleSettingResponse.configured(setting, unavailableTimes, LocalDateTime.now());
+    }
 
     @Transactional
     public SaveScheduleSettingResponse save(

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/AdminScheduleController.java
@@ -5,6 +5,7 @@ import com.better.CommuteMate.global.controller.dtos.Response;
 import com.better.CommuteMate.schedule.application.MonthlyScheduleSettingService;
 import com.better.CommuteMate.schedule.controller.admin.dtos.SaveScheduleSettingRequest;
 import com.better.CommuteMate.schedule.controller.admin.dtos.SaveScheduleSettingResponse;
+import com.better.CommuteMate.schedule.controller.admin.dtos.ScheduleSettingResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +32,35 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminScheduleController {
 
     private final MonthlyScheduleSettingService monthlyScheduleSettingService;
+
+    @GetMapping("/work-application-settings/{year}/{month}")
+    @Operation(
+            summary = "월별 근로신청 설정 조회",
+            description = "관리자 조직의 월별 근로신청 설정을 조회합니다. 설정이 없으면 isConfigured=false로 응답합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "근로신청 설정 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "조회 연도 또는 월 값이 올바르지 않음"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getScheduleSetting(
+            @Parameter(description = "조회 연도", example = "2026", required = true)
+            @PathVariable int year,
+            @Parameter(description = "조회 월", example = "4", required = true)
+            @PathVariable int month,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        ScheduleSettingResponse result = monthlyScheduleSettingService.get(
+                userDetails.getUser().getOrganizationId(), year, month
+        );
+        return ResponseEntity.ok(Response.of(
+                true,
+                "근로신청 설정을 조회했습니다.",
+                result
+        ));
+    }
 
     @PutMapping("/work-application-settings/{year}/{month}")
     @Operation(

--- a/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/ScheduleSettingResponse.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/admin/dtos/ScheduleSettingResponse.java
@@ -1,0 +1,122 @@
+package com.better.CommuteMate.schedule.controller.admin.dtos;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkScheduleSetting;
+import com.better.CommuteMate.domain.schedule.entity.WorkUnavailableTime;
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+
+public class ScheduleSettingResponse extends ResponseDetail {
+    public final int year;
+    public final int month;
+    public final boolean isConfigured;
+    public final boolean applyStarted;
+    public final LocalDate applyStartDate;
+    public final LocalDate applyEndDate;
+    public final Integer maxConcurrentWorkers;
+    public final Integer minWorkUnitMinutes;
+    public final Integer weeklyMinMinutes;
+    public final Integer weeklyMaxMinutes;
+    public final Integer monthlyMinMinutes;
+    public final Integer monthlyMaxMinutes;
+    public final List<LocalDate> unavailableDates;
+    public final List<UnavailableTimeRange> unavailableTimeRanges;
+
+    private ScheduleSettingResponse(
+            int year,
+            int month,
+            boolean isConfigured,
+            boolean applyStarted,
+            LocalDate applyStartDate,
+            LocalDate applyEndDate,
+            Integer maxConcurrentWorkers,
+            Integer minWorkUnitMinutes,
+            Integer weeklyMinMinutes,
+            Integer weeklyMaxMinutes,
+            Integer monthlyMinMinutes,
+            Integer monthlyMaxMinutes,
+            List<LocalDate> unavailableDates,
+            List<UnavailableTimeRange> unavailableTimeRanges
+    ) {
+        this.year = year;
+        this.month = month;
+        this.isConfigured = isConfigured;
+        this.applyStarted = applyStarted;
+        this.applyStartDate = applyStartDate;
+        this.applyEndDate = applyEndDate;
+        this.maxConcurrentWorkers = maxConcurrentWorkers;
+        this.minWorkUnitMinutes = minWorkUnitMinutes;
+        this.weeklyMinMinutes = weeklyMinMinutes;
+        this.weeklyMaxMinutes = weeklyMaxMinutes;
+        this.monthlyMinMinutes = monthlyMinMinutes;
+        this.monthlyMaxMinutes = monthlyMaxMinutes;
+        this.unavailableDates = unavailableDates;
+        this.unavailableTimeRanges = unavailableTimeRanges;
+    }
+
+    public static ScheduleSettingResponse notConfigured(int year, int month) {
+        return new ScheduleSettingResponse(
+                year, month, false, false,
+                null, null, null, null, null, null, null, null,
+                List.of(), List.of()
+        );
+    }
+
+    public static ScheduleSettingResponse configured(
+            WorkScheduleSetting setting,
+            List<WorkUnavailableTime> unavailableTimes,
+            LocalDateTime now
+    ) {
+        List<LocalDate> unavailableDates = unavailableTimes.stream()
+                .filter(ScheduleSettingResponse::isFullDay)
+                .map(WorkUnavailableTime::getDate)
+                .distinct()
+                .sorted()
+                .toList();
+        List<UnavailableTimeRange> unavailableTimeRanges = unavailableTimes.stream()
+                .filter(time -> !isFullDay(time))
+                .map(time -> new UnavailableTimeRange(time.getStartTime(), time.getEndTime()))
+                .distinct()
+                .sorted(Comparator.comparing(UnavailableTimeRange::start)
+                        .thenComparing(UnavailableTimeRange::end))
+                .toList();
+
+        return new ScheduleSettingResponse(
+                setting.getYear(),
+                setting.getMonth(),
+                true,
+                Boolean.TRUE.equals(setting.getApplyEnabled())
+                        && !now.isBefore(setting.getApplyStartAt()),
+                setting.getApplyStartAt().toLocalDate(),
+                setting.getApplyEndAt().toLocalDate(),
+                setting.getMaxConcurrentWorkers(),
+                setting.getMinWorkUnitMinutes(),
+                setting.getWeeklyMinMinutes(),
+                setting.getWeeklyMaxMinutes(),
+                setting.getMonthlyMinMinutes(),
+                setting.getMonthlyMaxMinutes(),
+                unavailableDates,
+                unavailableTimeRanges
+        );
+    }
+
+    private static boolean isFullDay(WorkUnavailableTime time) {
+        return LocalTime.MIN.equals(time.getStartTime())
+                // PostgreSQL의 time 타입은 나노초 일부를 반올림할 수 있어 초 단위로 판별합니다.
+                && time.getEndTime().toSecondOfDay() == LocalTime.MAX.toSecondOfDay();
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+
+    public record UnavailableTimeRange(LocalTime start, LocalTime end) {
+    }
+}

--- a/src/test/java/com/better/CommuteMate/attendance/application/AttendanceIntegrationTest.java
+++ b/src/test/java/com/better/CommuteMate/attendance/application/AttendanceIntegrationTest.java
@@ -54,7 +54,7 @@ class AttendanceIntegrationTest {
         testUser = User.builder().userId(1L).name("Test User").build();
         LocalDateTime now = LocalDateTime.now();
         testSchedule = WorkSchedule.builder()
-                .scheduleId("100")
+                .scheduleId(100L)
                 .user(testUser)
                 .date(now.toLocalDate())
                 .startTime(now.minusHours(1).toLocalTime())
@@ -75,12 +75,12 @@ class AttendanceIntegrationTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
         when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(anyLong(), any(), any(), anyList()))
                 .thenReturn(List.of(testSchedule));
-        when(workAttendanceRepository.findBySchedule_ScheduleId("100")).thenReturn(Collections.emptyList());
+        when(workAttendanceRepository.findBySchedule_ScheduleId(100L)).thenReturn(Collections.emptyList());
 
         workAttendanceService.checkIn(1L, token);
         
         verify(workAttendanceRepository, times(1)).save(argThat(a -> 
-            a.getCheckTypeCode() == CodeType.CT01 && a.getSchedule().getScheduleId().equals("100")
+            a.getCheckTypeCode() == CodeType.CT01 && a.getSchedule().getScheduleId().equals(100L)
         ));
 
         // 3. Check Out
@@ -93,7 +93,7 @@ class AttendanceIntegrationTest {
                 .checkTime(LocalDateTime.now())
                 .build();
         
-        when(workAttendanceRepository.findBySchedule_ScheduleId("100")).thenReturn(List.of(checkInRecord));
+        when(workAttendanceRepository.findBySchedule_ScheduleId(100L)).thenReturn(List.of(checkInRecord));
         
         // Generate new token for checkout (simulating time passing or fresh token)
         QrTokenResponse tokenResponse2 = workAttendanceService.generateQrToken();
@@ -102,7 +102,7 @@ class AttendanceIntegrationTest {
         workAttendanceService.checkOut(1L, token2);
 
         verify(workAttendanceRepository, times(1)).save(argThat(a -> 
-            a.getCheckTypeCode() == CodeType.CT02 && a.getSchedule().getScheduleId().equals("100")
+            a.getCheckTypeCode() == CodeType.CT02 && a.getSchedule().getScheduleId().equals(100L)
         ));
     }
 

--- a/src/test/java/com/better/CommuteMate/attendance/application/WorkAttendanceServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/attendance/application/WorkAttendanceServiceTest.java
@@ -82,7 +82,7 @@ class WorkAttendanceServiceTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         WorkSchedule schedule = WorkSchedule.builder()
-                .scheduleId("1")
+                .scheduleId(1L)
                 .date(now.toLocalDate())
                 .startTime(now.plusHours(1).toLocalTime()) // 1 hour later
                 .endTime(now.plusHours(4).toLocalTime())
@@ -106,7 +106,7 @@ class WorkAttendanceServiceTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         WorkSchedule schedule = WorkSchedule.builder()
-                .scheduleId("1")
+                .scheduleId(1L)
                 .date(now.toLocalDate())
                 .startTime(now.minusMinutes(5).toLocalTime()) // Started 5 mins ago
                 .endTime(now.plusHours(3).toLocalTime())
@@ -121,7 +121,7 @@ class WorkAttendanceServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(User.builder().userId(1L).build()));
         when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(anyLong(), any(), any(), anyList()))
                 .thenReturn(List.of(schedule));
-        when(workAttendanceRepository.findBySchedule_ScheduleId("1")).thenReturn(List.of(existing));
+        when(workAttendanceRepository.findBySchedule_ScheduleId(1L)).thenReturn(List.of(existing));
 
         // When & Then
         assertThatThrownBy(() -> workAttendanceService.checkIn(1L, "valid"))
@@ -135,7 +135,7 @@ class WorkAttendanceServiceTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         WorkSchedule schedule = WorkSchedule.builder()
-                .scheduleId("1")
+                .scheduleId(1L)
                 .date(now.toLocalDate())
                 .startTime(now.minusMinutes(5).toLocalTime())
                 .endTime(now.plusHours(3).toLocalTime())
@@ -146,7 +146,7 @@ class WorkAttendanceServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(User.builder().userId(1L).build()));
         when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(anyLong(), any(), any(), anyList()))
                 .thenReturn(List.of(schedule));
-        when(workAttendanceRepository.findBySchedule_ScheduleId("1")).thenReturn(Collections.emptyList());
+        when(workAttendanceRepository.findBySchedule_ScheduleId(1L)).thenReturn(Collections.emptyList());
 
         // When
         workAttendanceService.checkIn(1L, "valid");
@@ -161,7 +161,7 @@ class WorkAttendanceServiceTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         WorkSchedule schedule = WorkSchedule.builder()
-                .scheduleId("1")
+                .scheduleId(1L)
                 .date(now.toLocalDate())
                 .startTime(now.minusHours(3).toLocalTime())
                 .endTime(now.minusMinutes(1).toLocalTime())
@@ -173,7 +173,7 @@ class WorkAttendanceServiceTest {
         when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(anyLong(), any(), any(), anyList()))
                 .thenReturn(List.of(schedule));
         // No attendance records
-        when(workAttendanceRepository.findBySchedule_ScheduleId("1")).thenReturn(Collections.emptyList());
+        when(workAttendanceRepository.findBySchedule_ScheduleId(1L)).thenReturn(Collections.emptyList());
 
         // When & Then
         assertThatThrownBy(() -> workAttendanceService.checkOut(1L, "valid"))

--- a/src/test/java/com/better/CommuteMate/home/application/AdminUserAttendanceServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/home/application/AdminUserAttendanceServiceTest.java
@@ -72,7 +72,7 @@ class AdminUserAttendanceServiceTest {
                 .phoneNumber("010-0000-0000")
                 .build();
         WorkSchedule schedule = WorkSchedule.builder()
-                .scheduleId("schedule-1")
+                .scheduleId(1L)
                 .user(user)
                 .date(date)
                 .startTime(start)
@@ -102,7 +102,7 @@ class AdminUserAttendanceServiceTest {
         when(attendanceRepository.findAllByScheduleIn(List.of(schedule)))
                 .thenReturn(List.of(checkIn));
         when(settingRepository.findByOrganizationIdAndYearAndMonth(
-                "10", date.getYear(), date.getMonthValue()
+                10L, date.getYear(), date.getMonthValue()
         )).thenReturn(Optional.of(setting));
 
         var response = service.getUserAttendance(10L, date.toString(), null, null, null);

--- a/src/test/java/com/better/CommuteMate/home/application/HomeServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/home/application/HomeServiceTest.java
@@ -66,7 +66,7 @@ class HomeServiceTest {
         LocalDateTime endTime = now.plusHours(4);
 
         WorkSchedule schedule = WorkSchedule.builder()
-                .scheduleId("1")
+                .scheduleId(1L)
                 .date(now.toLocalDate())
                 .startTime(startTime.toLocalTime())
                 .endTime(endTime.toLocalTime())
@@ -86,7 +86,7 @@ class HomeServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(anyLong(), any(), any(), anyList()))
                 .thenReturn(new java.util.ArrayList<>(List.of(schedule)));
-        when(workAttendanceRepository.findBySchedule_ScheduleId("1"))
+        when(workAttendanceRepository.findBySchedule_ScheduleId(1L))
                 .thenReturn(List.of(checkIn, checkOut));
 
         // When
@@ -117,7 +117,7 @@ class HomeServiceTest {
         LocalDateTime now = LocalDateTime.now();
         // Starts in 1 hour
         WorkSchedule schedule = WorkSchedule.builder()
-                .scheduleId("1")
+                .scheduleId(1L)
                 .date(now.toLocalDate())
                 .startTime(now.plusHours(1).toLocalTime())
                 .endTime(now.plusHours(4).toLocalTime())
@@ -127,7 +127,7 @@ class HomeServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(anyLong(), any(), any(), anyList()))
                 .thenReturn(new java.util.ArrayList<>(List.of(schedule)));
-        when(workAttendanceRepository.findBySchedule_ScheduleId("1"))
+        when(workAttendanceRepository.findBySchedule_ScheduleId(1L))
                 .thenReturn(Collections.emptyList());
 
         HomeAttendanceStatusResponse response = homeService.getAttendanceStatus(1L);

--- a/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkChangeRequestProcessServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkChangeRequestProcessServiceTest.java
@@ -65,7 +65,7 @@ class AdminWorkChangeRequestProcessServiceTest {
     void approvesRequestByCancellingDeleteAndCreatingApprovedAdd() {
         WorkChangeRequest request = pendingRequest();
         WorkSchedule deletedSchedule = WorkSchedule.builder()
-                .scheduleId("delete-id")
+                .scheduleId(1L)
                 .user(request.getUser())
                 .date(LocalDate.of(2026, 6, 15))
                 .startTime(LocalTime.of(9, 0))
@@ -79,7 +79,7 @@ class AdminWorkChangeRequestProcessServiceTest {
                 request, CodeType.CR01, null, 17, 13, 15
         );
         WorkScheduleSetting setting = WorkScheduleSetting.builder()
-                .organizationId("10")
+                .organizationId(10L)
                 .year(2026)
                 .month(6)
                 .maxConcurrentWorkers(4)
@@ -88,9 +88,9 @@ class AdminWorkChangeRequestProcessServiceTest {
         when(requestRepository.findForProcessing(1L)).thenReturn(Optional.of(request));
         when(itemRepository.findAllByRequest_RequestId(1L))
                 .thenReturn(List.of(deleteItem, addItem));
-        when(workplaceRepository.findFirstByOrganizationId("10"))
-                .thenReturn(Optional.of(Workplace.builder().workplaceId("workplace").build()));
-        when(settingRepository.findForUpdate("10", 2026, 6))
+        when(workplaceRepository.findFirstByOrganizationId(10L))
+                .thenReturn(Optional.of(Workplace.builder().workplaceId(1L).build()));
+        when(settingRepository.findForUpdate(10L, 2026, 6))
                 .thenReturn(Optional.of(setting));
         when(scheduleValidator.isScheduleInsertable(
                 any(WorkScheduleSlotCommand.class), any(WorkScheduleSetting.class)
@@ -169,9 +169,9 @@ class AdminWorkChangeRequestProcessServiceTest {
         );
         when(requestRepository.findForProcessing(1L)).thenReturn(Optional.of(request));
         when(itemRepository.findAllByRequest_RequestId(1L)).thenReturn(List.of(addItem));
-        when(workplaceRepository.findFirstByOrganizationId("10"))
-                .thenReturn(Optional.of(Workplace.builder().workplaceId("workplace").build()));
-        when(settingRepository.findForUpdate("10", 2026, 6))
+        when(workplaceRepository.findFirstByOrganizationId(10L))
+                .thenReturn(Optional.of(Workplace.builder().workplaceId(1L).build()));
+        when(settingRepository.findForUpdate(10L, 2026, 6))
                 .thenReturn(Optional.of(WorkScheduleSetting.builder()
                         .maxConcurrentWorkers(4).build()));
         when(scheduleValidator.isScheduleInsertable(any(), any())).thenReturn(false);

--- a/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQueryServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/AdminWorkScheduleQueryServiceTest.java
@@ -63,7 +63,7 @@ class AdminWorkScheduleQueryServiceTest {
                 .endTime(LocalTime.of(10, 30))
                 .build();
 
-        when(settingRepository.findByOrganizationIdAndYearAndMonth("10", 2026, 4))
+        when(settingRepository.findByOrganizationIdAndYearAndMonth(10L, 2026, 4))
                 .thenReturn(Optional.of(setting));
         when(scheduleRepository.findAllBySettingAndDateBetweenAndStatusCodeIn(
                 setting, date, date, List.of(CodeType.WS01, CodeType.WS02)
@@ -71,7 +71,7 @@ class AdminWorkScheduleQueryServiceTest {
         when(unavailableTimeRepository.findBySettingAndDateBetween(setting, date, date))
                 .thenReturn(List.of(unavailable));
 
-        var response = service.getSchedules("10", "2026-04-15", "2026-04-15", null);
+        var response = service.getSchedules(10L, "2026-04-15", "2026-04-15", null);
 
         assertThat(response.maxConcurrentWorkers).isEqualTo(4);
         assertThat(response.hasPrev).isFalse();
@@ -89,7 +89,7 @@ class AdminWorkScheduleQueryServiceTest {
     @DisplayName("관리자 근로시간표 조회 - 조회 기간이 서로 다른 월이면 실패한다")
     void rejectsCrossMonthRange() {
         assertThatThrownBy(() -> service.getSchedules(
-                "10", "2026-04-30", "2026-05-01", null
+                10L, "2026-04-30", "2026-05-01", null
         ))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("조회 연도 또는 월 값이 올바르지 않습니다.");
@@ -98,14 +98,14 @@ class AdminWorkScheduleQueryServiceTest {
     @Test
     @DisplayName("관리자 근로시간표 조회 - 해당 월 설정이 없으면 빈 배열과 이전·다음 설정 여부를 반환한다")
     void returnsEmptyDaysWhenMonthlySettingDoesNotExist() {
-        when(settingRepository.findByOrganizationIdAndYearAndMonth("10", 2026, 4))
+        when(settingRepository.findByOrganizationIdAndYearAndMonth(10L, 2026, 4))
                 .thenReturn(Optional.empty());
-        when(settingRepository.existsByOrganizationIdAndYearAndMonth("10", 2026, 3))
+        when(settingRepository.existsByOrganizationIdAndYearAndMonth(10L, 2026, 3))
                 .thenReturn(true);
-        when(settingRepository.existsByOrganizationIdAndYearAndMonth("10", 2026, 5))
+        when(settingRepository.existsByOrganizationIdAndYearAndMonth(10L, 2026, 5))
                 .thenReturn(false);
 
-        var response = service.getSchedules("10", "2026-04-15", "2026-04-15", null);
+        var response = service.getSchedules(10L, "2026-04-15", "2026-04-15", null);
 
         assertThat(response.maxConcurrentWorkers).isEqualTo(4);
         assertThat(response.hasPrev).isTrue();
@@ -115,8 +115,8 @@ class AdminWorkScheduleQueryServiceTest {
 
     private WorkScheduleSetting setting() {
         return WorkScheduleSetting.builder()
-                .settingId("setting-1")
-                .organizationId("10")
+                .settingId(1L)
+                .organizationId(10L)
                 .year(2026)
                 .month(4)
                 .applyStartAt(LocalDateTime.of(2026, 4, 1, 0, 0))

--- a/src/test/java/com/better/CommuteMate/schedule/application/MonthlyScheduleSettingQueryTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/MonthlyScheduleSettingQueryTest.java
@@ -1,0 +1,119 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkScheduleSetting;
+import com.better.CommuteMate.domain.schedule.entity.WorkUnavailableTime;
+import com.better.CommuteMate.domain.schedule.repository.WorkScheduleSettingRepository;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.schedule.repository.WorkUnavailableTimeRepository;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MonthlyScheduleSettingQueryTest {
+
+    @Mock WorkScheduleSettingRepository settingRepository;
+    @Mock WorkSchedulesRepository scheduleRepository;
+    @Mock WorkUnavailableTimeRepository unavailableTimeRepository;
+
+    private MonthlyScheduleSettingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MonthlyScheduleSettingService(
+                settingRepository, scheduleRepository, unavailableTimeRepository
+        );
+    }
+
+    @Test
+    void returnsConfiguredSettingWithDistinctUnavailableValues() {
+        WorkScheduleSetting setting = WorkScheduleSetting.builder()
+                .settingId(1L)
+                .organizationId(10L)
+                .year(2026)
+                .month(4)
+                .applyStartAt(LocalDateTime.of(2000, 4, 1, 0, 0))
+                .applyEndAt(LocalDateTime.of(2026, 4, 10, 23, 59))
+                .applyEnabled(true)
+                .maxConcurrentWorkers(4)
+                .minWorkUnitMinutes(120)
+                .weeklyMinMinutes(300)
+                .weeklyMaxMinutes(540)
+                .monthlyMinMinutes(1200)
+                .monthlyMaxMinutes(1620)
+                .monthlyRequiredMinutes(1620)
+                .build();
+        WorkUnavailableTime fullDay = unavailable(
+                setting, LocalDate.of(2026, 4, 19), LocalTime.MIN, LocalTime.MAX
+        );
+        WorkUnavailableTime firstRange = unavailable(
+                setting, LocalDate.of(2026, 4, 1), LocalTime.of(11, 0), LocalTime.of(13, 0)
+        );
+        WorkUnavailableTime duplicatedRange = unavailable(
+                setting, LocalDate.of(2026, 4, 2), LocalTime.of(11, 0), LocalTime.of(13, 0)
+        );
+        when(settingRepository.findByOrganizationIdAndYearAndMonth(10L, 2026, 4))
+                .thenReturn(Optional.of(setting));
+        when(unavailableTimeRepository.findBySettingAndDateBetween(
+                setting, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 30)
+        )).thenReturn(List.of(fullDay, firstRange, duplicatedRange));
+
+        var response = service.get(10L, 2026, 4);
+
+        assertThat(response.isConfigured).isTrue();
+        assertThat(response.applyStarted).isTrue();
+        assertThat(response.unavailableDates).containsExactly(LocalDate.of(2026, 4, 19));
+        assertThat(response.unavailableTimeRanges).singleElement().satisfies(range -> {
+            assertThat(range.start()).isEqualTo(LocalTime.of(11, 0));
+            assertThat(range.end()).isEqualTo(LocalTime.of(13, 0));
+        });
+    }
+
+    @Test
+    void returnsNullSettingsWhenMonthIsNotConfigured() {
+        when(settingRepository.findByOrganizationIdAndYearAndMonth(10L, 2026, 4))
+                .thenReturn(Optional.empty());
+
+        var response = service.get(10L, 2026, 4);
+
+        assertThat(response.isConfigured).isFalse();
+        assertThat(response.applyStarted).isFalse();
+        assertThat(response.applyStartDate).isNull();
+        assertThat(response.maxConcurrentWorkers).isNull();
+        assertThat(response.unavailableDates).isEmpty();
+        assertThat(response.unavailableTimeRanges).isEmpty();
+    }
+
+    @Test
+    void rejectsInvalidYearOrMonth() {
+        assertThatThrownBy(() -> service.get(10L, 2026, 13))
+                .isInstanceOf(CustomException.class);
+    }
+
+    private WorkUnavailableTime unavailable(
+            WorkScheduleSetting setting,
+            LocalDate date,
+            LocalTime start,
+            LocalTime end
+    ) {
+        return WorkUnavailableTime.builder()
+                .setting(setting)
+                .date(date)
+                .startTime(start)
+                .endTime(end)
+                .build();
+    }
+}

--- a/src/test/java/com/better/CommuteMate/schedule/application/MonthlyScheduleSettingServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/MonthlyScheduleSettingServiceTest.java
@@ -48,8 +48,8 @@ class MonthlyScheduleSettingServiceTest {
     @DisplayName("근로신청 설정 저장 - 변경된 규칙과 충돌하는 기존 스케줄을 취소한다")
     void saveCancelsSchedulesConflictingWithNewRule() {
         WorkScheduleSetting setting = WorkScheduleSetting.builder()
-                .settingId("setting-1")
-                .organizationId("10")
+                .settingId(1L)
+                .organizationId(10L)
                 .year(2026)
                 .month(4)
                 .applyStartAt(LocalDateTime.of(2026, 4, 1, 0, 0))
@@ -60,7 +60,7 @@ class MonthlyScheduleSettingServiceTest {
                 .build();
         User user = User.builder().userId(1L).build();
         WorkSchedule schedule = WorkSchedule.builder()
-                .scheduleId("schedule-1")
+                .scheduleId(1L)
                 .setting(setting)
                 .user(user)
                 .date(LocalDate.of(2026, 4, 19))
@@ -71,13 +71,13 @@ class MonthlyScheduleSettingServiceTest {
                 .build();
         SaveScheduleSettingRequest request = validRequest();
 
-        when(settingRepository.findByOrganizationIdAndYearAndMonth("10", 2026, 4))
+        when(settingRepository.findByOrganizationIdAndYearAndMonth(10L, 2026, 4))
                 .thenReturn(Optional.of(setting));
         when(scheduleRepository.findAllBySettingAndStatusCodeIn(
                 setting, List.of(CodeType.WS01, CodeType.WS02)
         )).thenReturn(List.of(schedule));
 
-        var response = service.save("10", 2026, 4, request, "99");
+        var response = service.save(10L, 2026, 4, request, "99");
 
         assertThat(response.affectedScheduleCount).isEqualTo(1);
         assertThat(response.affectedUserCount).isEqualTo(1);
@@ -99,7 +99,7 @@ class MonthlyScheduleSettingServiceTest {
                 4, 120, 600, 540, 1200, 1620
         );
 
-        assertThatThrownBy(() -> service.save("10", 2026, 4, invalid, "99"))
+        assertThatThrownBy(() -> service.save(10L, 2026, 4, invalid, "99"))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("최소 근무시간은 최대 근무시간보다 작아야 합니다.");
     }

--- a/src/test/java/com/better/CommuteMate/schedule/application/ScheduleServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/ScheduleServiceTest.java
@@ -95,10 +95,10 @@ class ScheduleServiceTest {
         when(workSchedulesRepository.existsByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeNot(
                 1L, slot.date(), slot.start(), slot.end(), com.better.CommuteMate.global.code.CodeType.WS04))
                 .thenReturn(false);
-        when(workScheduleSettingService.getRequiredSetting("10", 2026, 8)).thenReturn(setting);
+        when(workScheduleSettingService.getRequiredSetting(10L, 2026, 8)).thenReturn(setting);
         when(scheduleValidator.isScheduleInsertable(slot, setting)).thenReturn(true);
-        when(workplaceRepository.findFirstByOrganizationId("10"))
-                .thenReturn(Optional.of(Workplace.builder().organizationId("10").name("본사").build()));
+        when(workplaceRepository.findFirstByOrganizationId(10L))
+                .thenReturn(Optional.of(Workplace.builder().organizationId(10L).name("본사").build()));
 
         WorkScheduleChangeResultCommand result = scheduleService.changeWorkSchedules(
                 new WorkScheduleChangeCommand(1L, List.of(slot), List.of())
@@ -118,7 +118,7 @@ class ScheduleServiceTest {
         when(userRepository.findByUserId(1L)).thenReturn(Optional.of(user));
         when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(any(), any(), any(), any()))
                 .thenReturn(List.of());
-        when(workScheduleSettingService.getRequiredSetting("10", 2026, 8)).thenReturn(setting);
+        when(workScheduleSettingService.getRequiredSetting(10L, 2026, 8)).thenReturn(setting);
         when(scheduleValidator.isScheduleInsertable(slot, setting)).thenReturn(false);
 
         WorkScheduleChangeResultCommand result = scheduleService.changeWorkSchedules(
@@ -141,7 +141,7 @@ class ScheduleServiceTest {
 
     private WorkScheduleSetting setting() {
         return WorkScheduleSetting.builder()
-                .organizationId("10")
+                .organizationId(10L)
                 .year(2026)
                 .month(8)
                 .maxConcurrentWorkers(3)


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
관리자가 특정 연월의 근로신청 설정을 조회할 수 있는 API를 구현했습니다.
설정이 없는 월도 정상적으로 화면을 구성할 수 있도록 200 응답과 함께 isConfigured: false를 반환하며, PK 타입을 Long으로 변경한 뒤 남아 있던 테스트 코드의 타입 불일치도 수정했습니다.
## 2. 관련 이슈 🔗

## 3. 주요 변경 사항 🔑
### 근로신청 설정 조회 API 구현
GET /api/v1/admin/work-application-settings/{year}/{month} 추가
- 로그인한 관리자의 조직을 기준으로 월별 설정 조회
- 신청 기간, 근무시간 제한 및 최대 동시 근무 인원 반환
- 신청 불가 일자와 불가 시간대 반환
- 신청 시작 여부를 applyStarted로 제공
### 설정이 없어도 404가 아닌 200으로 응답
- isConfigured: false 반환
- 설정 관련 값은 null로 반환
- 신청 불가 일자 및 시간대는 빈 배열로 반환
### Long 타입 전환에 따른 테스트 수정
- 테스트의 scheduleId, settingId, workplaceId, organizationId를 Long 타입으로 변경
## 4. 기타 💬
