### PR TITLE
feat: 근무 일정 슬롯 단위 저장 및 홈 화면 오늘 근무 조회/출근 API 구현

### DIFF
--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/AttendanceErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/AttendanceErrorCode.java
@@ -10,11 +10,14 @@ public enum AttendanceErrorCode implements CustomErrorCode {
     INVALID_QR_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 QR 토큰입니다."),
     NOT_WORK_TIME(HttpStatus.BAD_REQUEST, "출퇴근 가능한 시간이 아닙니다."),
     NO_SCHEDULE_FOUND(HttpStatus.NOT_FOUND, "오늘 예정된 근무 일정이 없습니다."),
-    ALREADY_CHECKED_IN(HttpStatus.CONFLICT, "이미 출근 처리되었습니다."),
+    ALREADY_CHECKED_IN(HttpStatus.CONFLICT, "이미 출근 처리된 근무입니다."),
     ALREADY_CHECKED_OUT(HttpStatus.CONFLICT, "이미 퇴근 처리되었습니다."),
     CHECK_IN_REQUIRED(HttpStatus.BAD_REQUEST, "먼저 출근 처리가 필요합니다."),
     TOO_EARLY_CHECK_IN(HttpStatus.BAD_REQUEST, "출근 가능 시간이 아닙니다. (근무 시작 10분 전부터 가능)"),
     TOO_LATE_CHECK_OUT(HttpStatus.BAD_REQUEST, "퇴근 가능 시간이 아닙니다."),
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "근무 일정을 찾을 수 없습니다."),
+    NOT_CONSECUTIVE_SLOTS(HttpStatus.BAD_REQUEST, "연속된 근무 일정이 아닙니다."),
+    CHECK_IN_LATE(HttpStatus.CONFLICT, "출근 가능 시간이 지나 결근 처리되었습니다."),
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
@@ -36,7 +36,8 @@ public enum ScheduleErrorCode implements CustomErrorCode {
     EDIT_REQUEST_EMPTY("수정 요청 항목이 없습니다.", "[Error] : 수정 요청 항목 없음", HttpStatus.BAD_REQUEST),
     EDIT_REQUEST_REASON_REQUIRED("수정 요청 사유를 입력해야 합니다.", "[Error] : 수정 요청 사유 미입력", HttpStatus.BAD_REQUEST),
     DELETE_SCHEDULE_NOT_FOUND("삭제 요청한 스케줄을 찾을 수 없습니다.", "[Error] : 삭제 요청 스케줄 미존재", HttpStatus.NOT_FOUND),
-    CROSS_WEEK_RANGE_NOT_ALLOWED("조회 기간은 같은 주 이내여야 합니다.", "[Error] : 다른 주에 걸친 조회 범위", HttpStatus.BAD_REQUEST);
+    CROSS_WEEK_RANGE_NOT_ALLOWED("조회 기간은 같은 주 이내여야 합니다.", "[Error] : 다른 주에 걸친 조회 범위", HttpStatus.BAD_REQUEST),
+    INVALID_SLOT_UNIT("근무 시간은 최소 근무 단위 기준으로 신청해야 합니다.", "[Error] : 최소 근무 단위 미준수", HttpStatus.BAD_REQUEST);
 
 
     private final String message;

--- a/src/main/java/com/better/CommuteMate/global/security/SecurityConfig.java
+++ b/src/main/java/com/better/CommuteMate/global/security/SecurityConfig.java
@@ -81,11 +81,15 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/admin/**", "/api/v1/admin/**").hasRole("RL02")
-                        // Task API만 인증 필요
                         .requestMatchers("/api/tasks/**", "/api/task-templates/**").authenticated()
-                        // 알림 API 인증 필요
-                        .requestMatchers("/api/v1/notifications/**").authenticated()
-                        // 나머지는 모두 허용
+                        .requestMatchers(
+                                "/api/v1/work-schedules/**",
+                                "/api/v1/work-change-requests/**",
+                                "/api/v1/notifications/**",
+                                "/api/v1/home/**",
+                                "/api/home/**",
+                                "/api/mypage/**"
+                        ).hasRole("RL01")
                         .anyRequest().permitAll()
                 )
                 .exceptionHandling(ex -> ex

--- a/src/main/java/com/better/CommuteMate/home/application/HomeService.java
+++ b/src/main/java/com/better/CommuteMate/home/application/HomeService.java
@@ -11,6 +11,7 @@ import com.better.CommuteMate.global.exceptions.error.GlobalErrorCode;
 import com.better.CommuteMate.home.controller.dto.HomeAttendanceStatusResponse;
 import com.better.CommuteMate.home.controller.dto.HomeAttendanceStatusResponse.AttendanceStatus;
 import com.better.CommuteMate.home.controller.dto.HomeWorkTimeResponse;
+import com.better.CommuteMate.home.controller.dto.TodayScheduleResponse;
 import com.better.CommuteMate.home.controller.dto.WeeklyWorkSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,10 +21,13 @@ import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +41,57 @@ public class HomeService {
             CodeType.WS01,
             CodeType.WS02
     );
+
+    @Transactional(readOnly = true)
+    public TodayScheduleResponse getTodaySchedules(Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
+
+        List<WorkSchedule> schedules = workSchedulesRepository
+                .findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(userId, today, today, VALID_STATUS_CODES);
+        schedules.sort(Comparator.comparing(WorkSchedule::getStartTime));
+
+        if (schedules.isEmpty()) {
+            return TodayScheduleResponse.builder().date(today).schedules(List.of()).build();
+        }
+
+        Map<Long, WorkAttendance> checkInByScheduleId = workAttendanceRepository
+                .findAllByScheduleIn(schedules).stream()
+                .filter(a -> a.getCheckTypeCode() == CodeType.CT01)
+                .collect(Collectors.toMap(
+                        a -> a.getSchedule().getScheduleId(),
+                        a -> a,
+                        (a1, a2) -> a1
+                ));
+
+        List<TodayScheduleResponse.ScheduleItem> items = schedules.stream()
+                .map(s -> {
+                    WorkAttendance checkIn = checkInByScheduleId.get(s.getScheduleId());
+                    boolean checkedIn = checkIn != null;
+                    return TodayScheduleResponse.ScheduleItem.builder()
+                            .scheduleId(s.getScheduleId())
+                            .label(s.getStartTime().isBefore(LocalTime.NOON) ? "오전 근무" : "오후 근무")
+                            .start(s.getStartTime())
+                            .end(s.getEndTime())
+                            .workStatusCode(resolveWorkStatusCode(s, checkedIn, now))
+                            .checkedIn(checkedIn)
+                            .checkInTime(checkedIn ? checkIn.getCheckTime() : null)
+                            .build();
+                })
+                .toList();
+
+        return TodayScheduleResponse.builder().date(today).schedules(items).build();
+    }
+
+    private String resolveWorkStatusCode(WorkSchedule s, boolean checkedIn, LocalDateTime now) {
+        LocalDateTime end = LocalDateTime.of(s.getDate(), s.getEndTime());
+        LocalDateTime lateThreshold = LocalDateTime.of(s.getDate(), s.getStartTime()).plusMinutes(10);
+        if (checkedIn) {
+            return now.isBefore(end) ? CodeType.WK02.getFullCode() : CodeType.WK03.getFullCode();
+        } else {
+            return now.isAfter(lateThreshold) ? CodeType.WK04.getFullCode() : CodeType.WK01.getFullCode();
+        }
+    }
 
     /**
      * 오늘의 총 근무 시간(분 단위)과 예정된 스케줄 개수를 조회합니다.

--- a/src/main/java/com/better/CommuteMate/home/application/HomeService.java
+++ b/src/main/java/com/better/CommuteMate/home/application/HomeService.java
@@ -8,8 +8,12 @@ import com.better.CommuteMate.domain.workattendance.repository.WorkAttendanceRep
 import com.better.CommuteMate.global.code.CodeType;
 import com.better.CommuteMate.global.exceptions.CustomException;
 import com.better.CommuteMate.global.exceptions.error.GlobalErrorCode;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.AttendanceErrorCode;
 import com.better.CommuteMate.home.controller.dto.HomeAttendanceStatusResponse;
 import com.better.CommuteMate.home.controller.dto.HomeAttendanceStatusResponse.AttendanceStatus;
+import com.better.CommuteMate.home.controller.dto.HomeCheckInResponse;
 import com.better.CommuteMate.home.controller.dto.HomeWorkTimeResponse;
 import com.better.CommuteMate.home.controller.dto.TodayScheduleResponse;
 import com.better.CommuteMate.home.controller.dto.WeeklyWorkSummaryResponse;
@@ -26,6 +30,7 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -37,26 +42,24 @@ public class HomeService {
     private final WorkAttendanceRepository workAttendanceRepository;
     private final UserRepository userRepository;
 
-    private static final List<CodeType> VALID_STATUS_CODES = List.of(
-            CodeType.WS01,
-            CodeType.WS02
-    );
+    private static final List<CodeType> VALID_STATUS_CODES = List.of(CodeType.WS01, CodeType.WS02);
+    private static final int CHECK_IN_GRACE_MINUTES = 10;
 
     @Transactional(readOnly = true)
     public TodayScheduleResponse getTodaySchedules(Long userId) {
         LocalDate today = LocalDate.now();
         LocalDateTime now = LocalDateTime.now();
 
-        List<WorkSchedule> schedules = workSchedulesRepository
+        List<WorkSchedule> slots = workSchedulesRepository
                 .findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(userId, today, today, VALID_STATUS_CODES);
-        schedules.sort(Comparator.comparing(WorkSchedule::getStartTime));
+        slots.sort(Comparator.comparing(WorkSchedule::getStartTime));
 
-        if (schedules.isEmpty()) {
+        if (slots.isEmpty()) {
             return TodayScheduleResponse.builder().date(today).schedules(List.of()).build();
         }
 
         Map<Long, WorkAttendance> checkInByScheduleId = workAttendanceRepository
-                .findAllByScheduleIn(schedules).stream()
+                .findAllByScheduleIn(slots).stream()
                 .filter(a -> a.getCheckTypeCode() == CodeType.CT01)
                 .collect(Collectors.toMap(
                         a -> a.getSchedule().getScheduleId(),
@@ -64,18 +67,27 @@ public class HomeService {
                         (a1, a2) -> a1
                 ));
 
-        List<TodayScheduleResponse.ScheduleItem> items = schedules.stream()
-                .map(s -> {
-                    WorkAttendance checkIn = checkInByScheduleId.get(s.getScheduleId());
-                    boolean checkedIn = checkIn != null;
+        List<TodayScheduleResponse.ScheduleItem> items = ScheduleSlotUtils.mergeConsecutiveSlots(slots).stream()
+                .map(group -> {
+                    WorkSchedule first = group.get(0);
+                    WorkSchedule last = group.get(group.size() - 1);
+                    List<Long> scheduleIds = group.stream().map(WorkSchedule::getScheduleId).toList();
+
+                    Optional<WorkAttendance> earliest = group.stream()
+                            .map(s -> checkInByScheduleId.get(s.getScheduleId()))
+                            .filter(Objects::nonNull)
+                            .min(Comparator.comparing(WorkAttendance::getCheckTime));
+
+                    boolean checkedIn = earliest.isPresent();
                     return TodayScheduleResponse.ScheduleItem.builder()
-                            .scheduleId(s.getScheduleId())
-                            .label(s.getStartTime().isBefore(LocalTime.NOON) ? "오전 근무" : "오후 근무")
-                            .start(s.getStartTime())
-                            .end(s.getEndTime())
-                            .workStatusCode(resolveWorkStatusCode(s, checkedIn, now))
+                            .scheduleIds(scheduleIds)
+                            .label(first.getStartTime().isBefore(LocalTime.NOON) ? "오전 근무" : "오후 근무")
+                            .start(first.getStartTime())
+                            .end(last.getEndTime())
+                            .workStatusCode(resolveWorkStatusCode(
+                                    today, first.getStartTime(), last.getEndTime(), checkedIn, now))
                             .checkedIn(checkedIn)
-                            .checkInTime(checkedIn ? checkIn.getCheckTime() : null)
+                            .checkInTime(checkedIn ? earliest.get().getCheckTime() : null)
                             .build();
                 })
                 .toList();
@@ -83,9 +95,62 @@ public class HomeService {
         return TodayScheduleResponse.builder().date(today).schedules(items).build();
     }
 
-    private String resolveWorkStatusCode(WorkSchedule s, boolean checkedIn, LocalDateTime now) {
-        LocalDateTime end = LocalDateTime.of(s.getDate(), s.getEndTime());
-        LocalDateTime lateThreshold = LocalDateTime.of(s.getDate(), s.getStartTime()).plusMinutes(10);
+    @Transactional
+    public HomeCheckInResponse checkIn(Long userId, List<Long> scheduleIds) {
+        List<WorkSchedule> schedules = workSchedulesRepository.findAllById(scheduleIds);
+        LocalDate today = LocalDate.now();
+
+        if (schedules.size() != scheduleIds.size()
+                || schedules.stream().anyMatch(s -> !s.getUser().getUserId().equals(userId))
+                || schedules.stream().anyMatch(s -> !s.getDate().equals(today))
+                || schedules.stream().anyMatch(s -> s.getStatusCode() == CodeType.WS04)) {
+            throw CustomException.of(AttendanceErrorCode.SCHEDULE_NOT_FOUND);
+        }
+
+        schedules.sort(Comparator.comparing(WorkSchedule::getStartTime));
+
+        if (!ScheduleSlotUtils.isConsecutive(schedules)) {
+            throw CustomException.of(AttendanceErrorCode.NOT_CONSECUTIVE_SLOTS);
+        }
+
+        boolean alreadyCheckedIn = workAttendanceRepository.findAllByScheduleIn(schedules).stream()
+                .anyMatch(a -> a.getCheckTypeCode() == CodeType.CT01);
+        if (alreadyCheckedIn) {
+            throw CustomException.of(AttendanceErrorCode.ALREADY_CHECKED_IN);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        WorkSchedule firstSlot = schedules.get(0);
+        LocalDateTime lateThreshold = LocalDateTime.of(firstSlot.getDate(), firstSlot.getStartTime())
+                .plusMinutes(CHECK_IN_GRACE_MINUTES);
+        if (now.isAfter(lateThreshold)) {
+            throw CustomException.of(AttendanceErrorCode.CHECK_IN_LATE);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));
+
+        List<WorkAttendance> records = schedules.stream()
+                .map(s -> WorkAttendance.builder()
+                        .user(user)
+                        .schedule(s)
+                        .checkTime(now)
+                        .checkTypeCode(CodeType.CT01)
+                        .verified(true)
+                        .build())
+                .toList();
+        workAttendanceRepository.saveAll(records);
+
+        return HomeCheckInResponse.builder()
+                .scheduleIds(scheduleIds)
+                .checkInTime(now)
+                .build();
+    }
+
+    private String resolveWorkStatusCode(LocalDate date, LocalTime mergedStart, LocalTime mergedEnd,
+                                          boolean checkedIn, LocalDateTime now) {
+        LocalDateTime end = LocalDateTime.of(date, mergedEnd);
+        LocalDateTime lateThreshold = LocalDateTime.of(date, mergedStart).plusMinutes(CHECK_IN_GRACE_MINUTES);
         if (checkedIn) {
             return now.isBefore(end) ? CodeType.WK02.getFullCode() : CodeType.WK03.getFullCode();
         } else {

--- a/src/main/java/com/better/CommuteMate/home/application/ScheduleSlotUtils.java
+++ b/src/main/java/com/better/CommuteMate/home/application/ScheduleSlotUtils.java
@@ -1,0 +1,50 @@
+package com.better.CommuteMate.home.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ScheduleSlotUtils {
+
+    private ScheduleSlotUtils() {}
+
+    /**
+     * start_time 오름차순으로 정렬된 슬롯 목록을 연속된 그룹으로 병합한다.
+     * 앞 슬롯의 end_time == 뒤 슬롯의 start_time 일 때만 이어붙인다.
+     */
+    public static List<List<WorkSchedule>> mergeConsecutiveSlots(List<WorkSchedule> sortedSlots) {
+        List<List<WorkSchedule>> groups = new ArrayList<>();
+        if (sortedSlots.isEmpty()) {
+            return groups;
+        }
+        List<WorkSchedule> current = new ArrayList<>();
+        current.add(sortedSlots.get(0));
+        for (int i = 1; i < sortedSlots.size(); i++) {
+            WorkSchedule prev = sortedSlots.get(i - 1);
+            WorkSchedule next = sortedSlots.get(i);
+            if (prev.getEndTime().equals(next.getStartTime())) {
+                current.add(next);
+            } else {
+                groups.add(new ArrayList<>(current));
+                current = new ArrayList<>();
+                current.add(next);
+            }
+        }
+        groups.add(current);
+        return groups;
+    }
+
+    /**
+     * start_time 오름차순으로 정렬된 슬롯 목록이 끊김 없이 연속되는지 검사한다.
+     * 단일 슬롯은 항상 true.
+     */
+    public static boolean isConsecutive(List<WorkSchedule> sortedSlots) {
+        for (int i = 1; i < sortedSlots.size(); i++) {
+            if (!sortedSlots.get(i - 1).getEndTime().equals(sortedSlots.get(i).getStartTime())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/better/CommuteMate/home/controller/HomeTodayController.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/HomeTodayController.java
@@ -1,0 +1,82 @@
+package com.better.CommuteMate.home.controller;
+
+import com.better.CommuteMate.auth.application.CustomUserDetails;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.home.application.HomeService;
+import com.better.CommuteMate.home.controller.dto.TodayScheduleResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "홈 화면", description = "홈 화면용 정보 조회 API")
+@RestController
+@RequestMapping("/api/v1/home")
+@RequiredArgsConstructor
+public class HomeTodayController {
+
+    private final HomeService homeService;
+
+    @GetMapping("/today")
+    @Operation(
+            summary = "오늘 근무 일정 목록 조회",
+            description = "오늘 날짜의 승인·신청 상태인 근무 일정 목록과 각 일정의 실시간 근무 상태를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "조회 성공",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "message": "오늘 근무 일정 조회 성공",
+                                              "details": {
+                                                "date": "2026-10-13",
+                                                "schedules": [
+                                                  {
+                                                    "scheduleId": 1,
+                                                    "label": "오전 근무",
+                                                    "start": "09:00",
+                                                    "end": "12:00",
+                                                    "workStatusCode": "WK02",
+                                                    "checkedIn": true,
+                                                    "checkInTime": "2026-10-13T09:02:00"
+                                                  },
+                                                  {
+                                                    "scheduleId": 2,
+                                                    "label": "오후 근무",
+                                                    "start": "13:00",
+                                                    "end": "17:00",
+                                                    "workStatusCode": "WK01",
+                                                    "checkedIn": false,
+                                                    "checkInTime": null
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getTodaySchedules(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        TodayScheduleResponse response = homeService.getTodaySchedules(userDetails.getUser().getUserId());
+        return ResponseEntity.ok(Response.of(true, "오늘 근무 일정 조회 성공", response));
+    }
+}

--- a/src/main/java/com/better/CommuteMate/home/controller/HomeTodayController.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/HomeTodayController.java
@@ -3,6 +3,8 @@ package com.better.CommuteMate.home.controller;
 import com.better.CommuteMate.auth.application.CustomUserDetails;
 import com.better.CommuteMate.global.controller.dtos.Response;
 import com.better.CommuteMate.home.application.HomeService;
+import com.better.CommuteMate.home.controller.dto.HomeCheckInRequest;
+import com.better.CommuteMate.home.controller.dto.HomeCheckInResponse;
 import com.better.CommuteMate.home.controller.dto.TodayScheduleResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,10 +13,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,8 +33,12 @@ public class HomeTodayController {
 
     @GetMapping("/today")
     @Operation(
-            summary = "오늘 근무 일정 목록 조회",
-            description = "오늘 날짜의 승인·신청 상태인 근무 일정 목록과 각 일정의 실시간 근무 상태를 조회합니다."
+            summary = "오늘 근무 일정 조회",
+            description = """
+                    오늘 날짜의 근무 일정(신청·승인 상태)을 조회합니다.
+                    연속된 슬롯은 하나의 근무 카드로 병합되며, 병합에 포함된 슬롯 ID 목록(scheduleIds)을 함께 반환합니다.
+                    workStatusCode는 현재 시각 기준 실시간으로 계산됩니다.
+                    """
     )
     @ApiResponses({
             @ApiResponse(
@@ -38,28 +47,28 @@ public class HomeTodayController {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    name = "조회 성공",
+                                    name = "조회 성공 (2개 근무 카드)",
                                     value = """
                                             {
                                               "isSuccess": true,
-                                              "message": "오늘 근무 일정 조회 성공",
+                                              "message": "오늘의 근무 현황을 조회했습니다.",
                                               "details": {
                                                 "date": "2026-10-13",
                                                 "schedules": [
                                                   {
-                                                    "scheduleId": 1,
+                                                    "scheduleIds": [1, 2, 3, 4, 5],
                                                     "label": "오전 근무",
                                                     "start": "09:00",
-                                                    "end": "12:00",
+                                                    "end": "11:30",
                                                     "workStatusCode": "WK02",
                                                     "checkedIn": true,
                                                     "checkInTime": "2026-10-13T09:02:00"
                                                   },
                                                   {
-                                                    "scheduleId": 2,
+                                                    "scheduleIds": [6, 7, 8, 9],
                                                     "label": "오후 근무",
-                                                    "start": "13:00",
-                                                    "end": "17:00",
+                                                    "start": "13:30",
+                                                    "end": "15:30",
                                                     "workStatusCode": "WK01",
                                                     "checkedIn": false,
                                                     "checkInTime": null
@@ -77,6 +86,123 @@ public class HomeTodayController {
     public ResponseEntity<Response> getTodaySchedules(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         TodayScheduleResponse response = homeService.getTodaySchedules(userDetails.getUser().getUserId());
-        return ResponseEntity.ok(Response.of(true, "오늘 근무 일정 조회 성공", response));
+        return ResponseEntity.ok(Response.of(true, "오늘의 근무 현황을 조회했습니다.", response));
+    }
+
+    @PostMapping("/check-in")
+    @Operation(
+            summary = "홈 출근 처리",
+            description = """
+                    조회 API(`GET /api/v1/home/today`)에서 받은 병합 근무의 scheduleIds를 그대로 전달하면,
+                    해당 슬롯 전체에 출근 기록을 한 번에 남깁니다.
+                    - 출근 가능 시간: 첫 슬롯 start 기준 + 10분
+                    - 이미 출근되었거나 시간이 지난 경우 409 반환
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "출근 처리 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "출근 성공",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "message": "출근 처리되었습니다.",
+                                              "details": {
+                                                "scheduleIds": [1, 2, 3, 4, 5],
+                                                "checkInTime": "2026-10-13T09:02:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "입력값 오류 또는 연속되지 않은 슬롯",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "scheduleIds 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "출근할 근무 일정을 선택해야 합니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "연속되지 않은 슬롯",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "연속된 근무 일정이 아닙니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "일정 없음 또는 유효하지 않은 일정",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "일정 없음",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "message": "근무 일정을 찾을 수 없습니다.",
+                                              "details": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 출근됨 또는 출근 가능 시간 초과",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "이미 출근 처리됨",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "이미 출근 처리된 근무입니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "출근 가능 시간 초과",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "message": "출근 가능 시간이 지나 결근 처리되었습니다.",
+                                                      "details": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> checkIn(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody HomeCheckInRequest request) {
+        HomeCheckInResponse response = homeService.checkIn(
+                userDetails.getUser().getUserId(), request.getScheduleIds());
+        return ResponseEntity.ok(Response.of(true, "출근 처리되었습니다.", response));
     }
 }

--- a/src/main/java/com/better/CommuteMate/home/controller/dto/HomeCheckInRequest.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/dto/HomeCheckInRequest.java
@@ -1,0 +1,18 @@
+package com.better.CommuteMate.home.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class HomeCheckInRequest {
+
+    @NotEmpty(message = "출근할 근무 일정을 선택해야 합니다.")
+    @Schema(description = "출근할 병합 근무의 슬롯 ID 목록 (조회 API의 scheduleIds를 그대로 전달)",
+            example = "[1, 2, 3, 4, 5]")
+    private List<Long> scheduleIds;
+}

--- a/src/main/java/com/better/CommuteMate/home/controller/dto/HomeCheckInResponse.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/dto/HomeCheckInResponse.java
@@ -1,0 +1,28 @@
+package com.better.CommuteMate.home.controller.dto;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class HomeCheckInResponse extends ResponseDetail {
+
+    @Schema(description = "출근 처리된 슬롯 ID 목록", example = "[1, 2, 3, 4, 5]")
+    private List<Long> scheduleIds;
+
+    @Schema(description = "출근 시각", example = "2026-10-13T09:02:00")
+    private LocalDateTime checkInTime;
+
+    @Builder
+    public HomeCheckInResponse(List<Long> scheduleIds, LocalDateTime checkInTime) {
+        super();
+        this.scheduleIds = scheduleIds;
+        this.checkInTime = checkInTime;
+    }
+}

--- a/src/main/java/com/better/CommuteMate/home/controller/dto/TodayScheduleResponse.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/dto/TodayScheduleResponse.java
@@ -32,8 +32,8 @@ public class TodayScheduleResponse extends ResponseDetail {
     @Builder
     public static class ScheduleItem {
 
-        @Schema(description = "근무 일정 ID", example = "1")
-        private Long scheduleId;
+        @Schema(description = "병합된 근무 슬롯 ID 목록 (시간 순)", example = "[1, 2, 3, 4, 5]")
+        private List<Long> scheduleIds;
 
         @Schema(description = "근무 구분 라벨 (오전 12시 기준 오전/오후)", example = "오전 근무")
         private String label;

--- a/src/main/java/com/better/CommuteMate/home/controller/dto/TodayScheduleResponse.java
+++ b/src/main/java/com/better/CommuteMate/home/controller/dto/TodayScheduleResponse.java
@@ -1,0 +1,56 @@
+package com.better.CommuteMate.home.controller.dto;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class TodayScheduleResponse extends ResponseDetail {
+
+    @Schema(description = "조회 날짜", example = "2026-10-13")
+    private LocalDate date;
+
+    @Schema(description = "오늘 근무 일정 목록")
+    private List<ScheduleItem> schedules;
+
+    @Builder
+    public TodayScheduleResponse(LocalDate date, List<ScheduleItem> schedules) {
+        super();
+        this.date = date;
+        this.schedules = schedules;
+    }
+
+    @Getter
+    @Builder
+    public static class ScheduleItem {
+
+        @Schema(description = "근무 일정 ID", example = "1")
+        private Long scheduleId;
+
+        @Schema(description = "근무 구분 라벨 (오전 12시 기준 오전/오후)", example = "오전 근무")
+        private String label;
+
+        @Schema(description = "근무 시작 시각", example = "09:30")
+        private LocalTime start;
+
+        @Schema(description = "근무 종료 시각", example = "11:30")
+        private LocalTime end;
+
+        @Schema(description = "근무 상태 코드 (WK01: 예정, WK02: 근무중, WK03: 근무완료, WK04: 결근)", example = "WK02")
+        private String workStatusCode;
+
+        @Schema(description = "출근 여부", example = "true")
+        private boolean checkedIn;
+
+        @Schema(description = "출근 시각. 출근 전이면 null.", example = "2026-10-13T09:02:00", nullable = true)
+        private LocalDateTime checkInTime;
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkChangeRequestProcessService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkChangeRequestProcessService.java
@@ -14,6 +14,7 @@ import com.better.CommuteMate.global.code.CodeType;
 import com.better.CommuteMate.global.exceptions.CustomException;
 import com.better.CommuteMate.global.exceptions.error.ScheduleErrorCode;
 import com.better.CommuteMate.schedule.application.dtos.WorkScheduleSlotCommand;
+import com.better.CommuteMate.schedule.application.WorkSlotUtils;
 import com.better.CommuteMate.schedule.controller.admin.dtos.ProcessWorkChangeRequest;
 import com.better.CommuteMate.schedule.controller.admin.dtos.ProcessWorkChangeResponse;
 import com.better.CommuteMate.schedule.controller.dtos.NotificationMessage;
@@ -78,71 +79,71 @@ public class AdminWorkChangeRequestProcessService {
         List<ProcessWorkChangeResponse.ScheduleResult> deleted = new ArrayList<>();
         List<ProcessWorkChangeResponse.ScheduleResult> added = new ArrayList<>();
 
-        // 교체 대상 스케줄을 먼저 취소해야 같은 시간대의 신규 스케줄 정원을 정확히 계산할 수 있습니다.
+        // CR02: 교체 대상을 단위 슬롯 단위로 모두 취소한다.
+        // 취소를 먼저 완료해야 이후 CR01 정원 계산이 정확해진다.
         for (WorkChangeRequestItem item : items) {
             if (item.getChangeTypeCode() != CodeType.CR02) {
                 continue;
             }
-            WorkSchedule schedule = item.getSchedule();
-            if (schedule == null) {
-                schedule = scheduleRepository
+            YearMonth month = YearMonth.from(item.getDate());
+            WorkScheduleSetting setting = settingRepository.findForUpdate(
+                            organizationId, month.getYear(), month.getMonthValue())
+                    .orElseThrow(() -> CustomException.of(
+                            ScheduleErrorCode.ADMIN_SCHEDULE_SETTING_NOT_FOUND));
+
+            for (WorkScheduleSlotCommand unitSlot : WorkSlotUtils.splitIntoUnitSlots(
+                    item.getDate(), item.getStartTime(), item.getEndTime(),
+                    setting.getMinWorkUnitMinutes())) {
+                WorkSchedule schedule = scheduleRepository
                         .findByUser_UserIdAndDateAndStartTimeAndEndTime(
                                 request.getUser().getUserId(),
-                                item.getDate(),
-                                item.getStartTime(),
-                                item.getEndTime()
-                        )
+                                unitSlot.date(), unitSlot.start(), unitSlot.end())
                         .orElseThrow(() -> CustomException.of(
-                                ScheduleErrorCode.DELETE_SCHEDULE_NOT_FOUND
-                        ));
-                item.linkSchedule(schedule);
+                                ScheduleErrorCode.DELETE_SCHEDULE_NOT_FOUND));
+                schedule.cancel(String.valueOf(adminId));
+                deleted.add(toResult(schedule));
             }
-            schedule.cancel(String.valueOf(adminId));
-            deleted.add(toResult(schedule));
         }
-        // 이후 정원 조회 쿼리가 취소 상태를 반영하도록 영속성 컨텍스트를 DB에 동기화합니다.
+        // 취소 상태를 DB에 반영해 이후 정원 조회가 올바른 값을 반환하도록 한다.
         scheduleRepository.flush();
 
         Workplace workplace = workplaceRepository
                 .findFirstByOrganizationId(organizationId)
                 .orElseThrow(() -> CustomException.of(ScheduleErrorCode.SCHEDULE_FAILURE));
 
+        // CR01: 원본 범위를 단위 슬롯으로 분할해 정원을 확인하고 저장한다.
         for (WorkChangeRequestItem item : items) {
             if (item.getChangeTypeCode() != CodeType.CR01) {
                 continue;
             }
             YearMonth month = YearMonth.from(item.getDate());
             WorkScheduleSetting setting = settingRepository.findForUpdate(
-                            organizationId,
-                            month.getYear(),
-                            month.getMonthValue()
-                    )
+                            organizationId, month.getYear(), month.getMonthValue())
                     .orElseThrow(() -> CustomException.of(
-                            ScheduleErrorCode.ADMIN_SCHEDULE_SETTING_NOT_FOUND
-                    ));
-            WorkScheduleSlotCommand slot = new WorkScheduleSlotCommand(
-                    item.getDate(), item.getStartTime(), item.getEndTime()
-            );
-            if (!scheduleValidator.isScheduleInsertable(slot, setting)) {
-                throw CustomException.of(ScheduleErrorCode.CHANGE_REQUEST_CAPACITY_EXCEEDED);
-            }
+                            ScheduleErrorCode.ADMIN_SCHEDULE_SETTING_NOT_FOUND));
 
-            WorkSchedule schedule = WorkSchedule.builder()
-                    .user(request.getUser())
-                    .setting(setting)
-                    .workplace(workplace)
-                    .date(item.getDate())
-                    .startTime(item.getStartTime())
-                    .endTime(item.getEndTime())
-                    .statusCode(CodeType.WS02)
-                    .createdRequestId(String.valueOf(requestId))
-                    .createdBy(String.valueOf(adminId))
-                    .updatedBy(String.valueOf(adminId))
-                    .build();
-            // 다음 추가 항목의 정원 검사에 현재 생성 건도 포함되도록 즉시 반영합니다.
-            scheduleRepository.saveAndFlush(schedule);
-            item.linkSchedule(schedule);
-            added.add(toResult(schedule));
+            for (WorkScheduleSlotCommand unitSlot : WorkSlotUtils.splitIntoUnitSlots(
+                    item.getDate(), item.getStartTime(), item.getEndTime(),
+                    setting.getMinWorkUnitMinutes())) {
+                if (!scheduleValidator.isScheduleInsertable(unitSlot, setting)) {
+                    throw CustomException.of(ScheduleErrorCode.CHANGE_REQUEST_CAPACITY_EXCEEDED);
+                }
+                WorkSchedule schedule = WorkSchedule.builder()
+                        .user(request.getUser())
+                        .setting(setting)
+                        .workplace(workplace)
+                        .date(unitSlot.date())
+                        .startTime(unitSlot.start())
+                        .endTime(unitSlot.end())
+                        .statusCode(CodeType.WS02)
+                        .createdRequestId(String.valueOf(requestId))
+                        .createdBy(String.valueOf(adminId))
+                        .updatedBy(String.valueOf(adminId))
+                        .build();
+                // 다음 단위 슬롯의 정원 검사에 현재 저장 건이 포함되도록 즉시 반영한다.
+                scheduleRepository.saveAndFlush(schedule);
+                added.add(toResult(schedule));
+            }
         }
 
         sendNotification(request, true);

--- a/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkChangeRequestProcessService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/AdminWorkChangeRequestProcessService.java
@@ -14,7 +14,6 @@ import com.better.CommuteMate.global.code.CodeType;
 import com.better.CommuteMate.global.exceptions.CustomException;
 import com.better.CommuteMate.global.exceptions.error.ScheduleErrorCode;
 import com.better.CommuteMate.schedule.application.dtos.WorkScheduleSlotCommand;
-import com.better.CommuteMate.schedule.application.WorkSlotUtils;
 import com.better.CommuteMate.schedule.controller.admin.dtos.ProcessWorkChangeRequest;
 import com.better.CommuteMate.schedule.controller.admin.dtos.ProcessWorkChangeResponse;
 import com.better.CommuteMate.schedule.controller.dtos.NotificationMessage;
@@ -23,11 +22,15 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -79,7 +82,7 @@ public class AdminWorkChangeRequestProcessService {
         List<ProcessWorkChangeResponse.ScheduleResult> deleted = new ArrayList<>();
         List<ProcessWorkChangeResponse.ScheduleResult> added = new ArrayList<>();
 
-        // CR02: 교체 대상을 단위 슬롯 단위로 모두 취소한다.
+        // === CR02: 교체 대상을 단위 슬롯 단위로 모두 취소한다.
         // 취소를 먼저 완료해야 이후 CR01 정원 계산이 정확해진다.
         for (WorkChangeRequestItem item : items) {
             if (item.getChangeTypeCode() != CodeType.CR02) {
@@ -91,15 +94,20 @@ public class AdminWorkChangeRequestProcessService {
                     .orElseThrow(() -> CustomException.of(
                             ScheduleErrorCode.ADMIN_SCHEDULE_SETTING_NOT_FOUND));
 
-            for (WorkScheduleSlotCommand unitSlot : WorkSlotUtils.splitIntoUnitSlots(
+            List<WorkScheduleSlotCommand> unitSlots = WorkSlotUtils.splitIntoUnitSlots(
                     item.getDate(), item.getStartTime(), item.getEndTime(),
-                    setting.getMinWorkUnitMinutes())) {
-                WorkSchedule schedule = scheduleRepository
+                    setting.getMinWorkUnitMinutes());
+
+            for (WorkScheduleSlotCommand unitSlot : unitSlots) {
+                Optional<WorkSchedule> scheduleOpt = scheduleRepository
                         .findByUser_UserIdAndDateAndStartTimeAndEndTime(
                                 request.getUser().getUserId(),
-                                unitSlot.date(), unitSlot.start(), unitSlot.end())
-                        .orElseThrow(() -> CustomException.of(
-                                ScheduleErrorCode.DELETE_SCHEDULE_NOT_FOUND));
+                                unitSlot.date(), unitSlot.start(), unitSlot.end());
+
+                if (scheduleOpt.isEmpty() || scheduleOpt.get().getStatusCode() == CodeType.WS04) {
+                    continue;
+                }
+                WorkSchedule schedule = scheduleOpt.get();
                 schedule.cancel(String.valueOf(adminId));
                 deleted.add(toResult(schedule));
             }
@@ -111,7 +119,12 @@ public class AdminWorkChangeRequestProcessService {
                 .findFirstByOrganizationId(organizationId)
                 .orElseThrow(() -> CustomException.of(ScheduleErrorCode.SCHEDULE_FAILURE));
 
-        // CR01: 원본 범위를 단위 슬롯으로 분할해 정원을 확인하고 저장한다.
+        // === CR01: 원본 범위를 단위 슬롯으로 분할해 정원을 확인하고 일괄 저장한다.
+        // daySchedulesMap: 날짜별 당일 근무 목록. 이미 추가한 슬롯도 여기에 넣어
+        // 다음 단위 슬롯의 정원 검사에 반영한다 (saveAll 전에 DB flush 없이도 정확한 검사 가능).
+        Map<LocalDate, List<WorkSchedule>> daySchedulesMap = new HashMap<>();
+        List<WorkSchedule> toSave = new ArrayList<>();
+
         for (WorkChangeRequestItem item : items) {
             if (item.getChangeTypeCode() != CodeType.CR01) {
                 continue;
@@ -122,10 +135,16 @@ public class AdminWorkChangeRequestProcessService {
                     .orElseThrow(() -> CustomException.of(
                             ScheduleErrorCode.ADMIN_SCHEDULE_SETTING_NOT_FOUND));
 
-            for (WorkScheduleSlotCommand unitSlot : WorkSlotUtils.splitIntoUnitSlots(
+            List<WorkScheduleSlotCommand> unitSlots = WorkSlotUtils.splitIntoUnitSlots(
                     item.getDate(), item.getStartTime(), item.getEndTime(),
-                    setting.getMinWorkUnitMinutes())) {
-                if (!scheduleValidator.isScheduleInsertable(unitSlot, setting)) {
+                    setting.getMinWorkUnitMinutes());
+
+            List<WorkSchedule> dayList = daySchedulesMap.computeIfAbsent(
+                    item.getDate(), d -> new ArrayList<>(scheduleRepository.findAllByDate(d)));
+
+            for (WorkScheduleSlotCommand unitSlot : unitSlots) {
+                if (!scheduleValidator.isScheduleInsertable(
+                        unitSlot, setting.getMaxConcurrentWorkers(), dayList)) {
                     throw CustomException.of(ScheduleErrorCode.CHANGE_REQUEST_CAPACITY_EXCEEDED);
                 }
                 WorkSchedule schedule = WorkSchedule.builder()
@@ -140,11 +159,16 @@ public class AdminWorkChangeRequestProcessService {
                         .createdBy(String.valueOf(adminId))
                         .updatedBy(String.valueOf(adminId))
                         .build();
-                // 다음 단위 슬롯의 정원 검사에 현재 저장 건이 포함되도록 즉시 반영한다.
-                scheduleRepository.saveAndFlush(schedule);
-                added.add(toResult(schedule));
+                // dayList에 포함시켜 다음 슬롯 정원 검사에 반영한다.
+                dayList.add(schedule);
+                toSave.add(schedule);
             }
         }
+
+        if (!toSave.isEmpty()) {
+            scheduleRepository.saveAll(toSave);
+        }
+        toSave.forEach(s -> added.add(toResult(s)));
 
         sendNotification(request, true);
         return new ProcessWorkChangeResponse(

--- a/src/main/java/com/better/CommuteMate/schedule/application/ScheduleService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/ScheduleService.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,14 +79,8 @@ public class ScheduleService {
     private static final LocalTime WORK_END_TIME = LocalTime.of(18, 0);
     private static final int SLOT_MINUTES = 30;
 
-    /**
-     * 근무 일정 변경사항을 반영합니다.
-     * addSlots는 새 일정을 추가하고, deleteSlots는 기존 일정을 취소합니다.
-     */
     @Transactional
-    public WorkScheduleChangeResultCommand changeWorkSchedules(
-            WorkScheduleChangeCommand command
-    ) {
+    public WorkScheduleChangeResultCommand changeWorkSchedules(WorkScheduleChangeCommand command) {
         validateChangeCommand(command);
 
         User user = userRepository.findByUserId(command.userId())
@@ -94,325 +89,312 @@ public class ScheduleService {
         List<WorkScheduleSlotCommand> addSlots = command.addSlots();
         List<WorkScheduleSlotCommand> deleteSlots = command.deleteSlots();
 
-        validateSlots(addSlots);
-        validateSlots(deleteSlots);
+        validateSlotsBasic(addSlots);
+        validateSlotsBasic(deleteSlots);
+
+        // 연월별 setting 로드: addSlots는 필수(없으면 404), deleteSlots는 Optional(없으면 단위 검증 스킵)
+        Map<YearMonth, WorkScheduleSetting> addSettings =
+                loadRequiredSettings(user.getOrganizationId(), addSlots);
+        Map<YearMonth, WorkScheduleSetting> allSettings =
+                loadOptionalSettings(user.getOrganizationId(), deleteSlots, addSettings);
+
+        validateSlotUnitAlignment(addSlots, allSettings);
+        validateSlotUnitAlignment(deleteSlots, allSettings);
 
         validateMonthlyLimit(command.userId(), addSlots, deleteSlots);
+
+        // 조회 일괄화: 사용자 슬롯 맵(중복·삭제 판단) + 날짜별 전체 근무(정원 판단)
+        Set<LocalDate> allDates = new HashSet<>();
+        addSlots.forEach(s -> allDates.add(s.date()));
+        deleteSlots.forEach(s -> allDates.add(s.date()));
+
+        Map<SlotKey, WorkSchedule> userScheduleMap = loadUserScheduleMap(command.userId(), allDates);
+
+        Map<LocalDate, List<WorkSchedule>> daySchedules = new HashMap<>();
+        addSlots.stream().map(WorkScheduleSlotCommand::date).distinct()
+                .forEach(d -> daySchedules.put(d, workSchedulesRepository.findAllByDate(d)));
 
         List<WorkScheduleChangeResponseDetail.Slot> success = new ArrayList<>();
         List<WorkScheduleChangeResponseDetail.Slot> failure = new ArrayList<>();
         List<ScheduleChange> changes = new ArrayList<>();
+        List<WorkSchedule> toSave = new ArrayList<>();
+        Set<SlotKey> tentativeSlotKeys = new HashSet<>();
 
         for (WorkScheduleSlotCommand slot : deleteSlots) {
-            deleteSlot(command.userId(), slot, success, failure, changes);
+            int unitMinutes = getUnitMinutes(allSettings, slot);
+            deleteSlotByRange(command.userId(), slot, unitMinutes,
+                    success, failure, changes, userScheduleMap);
         }
 
         for (WorkScheduleSlotCommand slot : addSlots) {
-            addSlot(user, slot, success, failure, changes);
+            WorkScheduleSetting setting = addSettings.get(YearMonth.from(slot.date()));
+            processAddSlot(user, slot, setting,
+                    success, failure, changes, toSave, daySchedules, userScheduleMap, tentativeSlotKeys);
+        }
+
+        if (!toSave.isEmpty()) {
+            workSchedulesRepository.saveAll(toSave);
         }
 
         broadcastScheduleUpdate(changes);
-
         return WorkScheduleChangeResultCommand.of(success, failure);
     }
 
-    /**
-     * 변경 요청이 비어있는지 검증합니다.
-     */
     private void validateChangeCommand(WorkScheduleChangeCommand command) {
         if (command == null || command.isEmpty()) {
             throw CustomException.of(ScheduleErrorCode.SCHEDULE_FAILURE);
         }
     }
 
-    /**
-     * 요청 슬롯의 날짜/시간 값과 30분 단위를 검증합니다.
-     */
-    private void validateSlots(List<WorkScheduleSlotCommand> slots) {
+    private void validateSlotsBasic(List<WorkScheduleSlotCommand> slots) {
         for (WorkScheduleSlotCommand slot : slots) {
             if (slot.date() == null || slot.start() == null || slot.end() == null) {
                 throw CustomException.of(ScheduleErrorCode.SCHEDULE_FAILURE);
             }
-
             if (!slot.start().isBefore(slot.end())) {
                 throw CustomException.of(ScheduleErrorCode.SCHEDULE_FAILURE);
             }
-
-            if (!isThirtyMinuteUnit(slot) || !isValidWorkUnit(slot)) {
-                throw CustomException.of(ScheduleErrorCode.SCHEDULE_FAILURE);
-            }
-
-            scheduleValidator.validateMinWorkTime(slot);
         }
     }
 
-    /**
-     * 시작/종료 시간이 30분 단위인지 확인합니다.
-     */
-    private boolean isThirtyMinuteUnit(WorkScheduleSlotCommand slot) {
-        return (slot.start().getMinute() == 0 || slot.start().getMinute() == 30)
-                && (slot.end().getMinute() == 0 || slot.end().getMinute() == 30);
+    private Map<YearMonth, WorkScheduleSetting> loadRequiredSettings(
+            Long organizationId, List<WorkScheduleSlotCommand> slots) {
+        Map<YearMonth, WorkScheduleSetting> map = new LinkedHashMap<>();
+        for (WorkScheduleSlotCommand slot : slots) {
+            YearMonth ym = YearMonth.from(slot.date());
+            map.computeIfAbsent(ym, k -> workScheduleSettingService.getRequiredSetting(
+                    organizationId, ym.getYear(), ym.getMonthValue()));
+        }
+        return map;
+    }
+
+    private Map<YearMonth, WorkScheduleSetting> loadOptionalSettings(
+            Long organizationId, List<WorkScheduleSlotCommand> slots,
+            Map<YearMonth, WorkScheduleSetting> alreadyLoaded) {
+        Map<YearMonth, WorkScheduleSetting> map = new LinkedHashMap<>(alreadyLoaded);
+        for (WorkScheduleSlotCommand slot : slots) {
+            YearMonth ym = YearMonth.from(slot.date());
+            if (!map.containsKey(ym)) {
+                workScheduleSettingService.getSetting(organizationId, ym.getYear(), ym.getMonthValue())
+                        .ifPresent(s -> map.put(ym, s));
+            }
+        }
+        return map;
+    }
+
+    private void validateSlotUnitAlignment(
+            List<WorkScheduleSlotCommand> slots,
+            Map<YearMonth, WorkScheduleSetting> settingsByMonth) {
+        for (WorkScheduleSlotCommand slot : slots) {
+            WorkScheduleSetting setting = settingsByMonth.get(YearMonth.from(slot.date()));
+            if (setting == null) continue;
+            int unitMinutes = setting.getMinWorkUnitMinutes();
+            int startTotalMinutes = slot.start().getHour() * 60 + slot.start().getMinute();
+            if (startTotalMinutes % unitMinutes != 0) {
+                throw CustomException.of(ScheduleErrorCode.INVALID_SLOT_UNIT);
+            }
+            long durationMinutes = Duration.between(slot.start(), slot.end()).toMinutes();
+            if (durationMinutes <= 0 || durationMinutes % unitMinutes != 0) {
+                throw CustomException.of(ScheduleErrorCode.INVALID_SLOT_UNIT);
+            }
+        }
+    }
+
+    private Map<SlotKey, WorkSchedule> loadUserScheduleMap(Long userId, Set<LocalDate> dates) {
+        if (dates.isEmpty()) return new HashMap<>();
+        LocalDate minDate = dates.stream().min(Comparator.naturalOrder()).orElseThrow();
+        LocalDate maxDate = dates.stream().max(Comparator.naturalOrder()).orElseThrow();
+        Map<SlotKey, WorkSchedule> map = new HashMap<>();
+        workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(
+                        userId, minDate, maxDate, CodeType.WS04)
+                .forEach(s -> map.put(new SlotKey(s.getDate(), s.getStartTime(), s.getEndTime()), s));
+        return map;
+    }
+
+    private int getUnitMinutes(Map<YearMonth, WorkScheduleSetting> settings,
+                               WorkScheduleSlotCommand slot) {
+        WorkScheduleSetting setting = settings.get(YearMonth.from(slot.date()));
+        return setting != null ? setting.getMinWorkUnitMinutes() : SLOT_MINUTES;
     }
 
     /**
-     * 근무 시간이 30분 단위로 나누어 떨어지는지 확인합니다.
+     * 원본 범위를 단위 슬롯으로 분할해 모두 찾아 취소한다.
+     * 하나라도 존재하지 않거나 이미 취소 상태면 전체 범위를 실패로 처리한다.
      */
-    private boolean isValidWorkUnit(WorkScheduleSlotCommand slot) {
-        long minutes = Duration.between(slot.start(), slot.end()).toMinutes();
-        return minutes % 30 == 0;
+    private void deleteSlotByRange(
+            Long userId,
+            WorkScheduleSlotCommand originalSlot,
+            int unitMinutes,
+            List<WorkScheduleChangeResponseDetail.Slot> success,
+            List<WorkScheduleChangeResponseDetail.Slot> failure,
+            List<ScheduleChange> changes,
+            Map<SlotKey, WorkSchedule> userScheduleMap) {
+
+        List<WorkScheduleSlotCommand> unitSlots = WorkSlotUtils.splitIntoUnitSlots(
+                originalSlot.date(), originalSlot.start(), originalSlot.end(), unitMinutes);
+
+        List<WorkSchedule> toCancel = new ArrayList<>();
+        for (WorkScheduleSlotCommand unitSlot : unitSlots) {
+            SlotKey key = new SlotKey(unitSlot.date(), unitSlot.start(), unitSlot.end());
+            WorkSchedule schedule = userScheduleMap.get(key);
+            if (schedule == null || schedule.getStatusCode().equals(CodeType.WS04)) {
+                failure.add(toResponseSlot(originalSlot));
+                return;
+            }
+            toCancel.add(schedule);
+        }
+
+        for (WorkSchedule schedule : toCancel) {
+            schedule.cancel(String.valueOf(userId));
+            changes.add(new ScheduleChange(false,
+                    LocalDateTime.of(schedule.getDate(), schedule.getStartTime()),
+                    LocalDateTime.of(schedule.getDate(), schedule.getEndTime())));
+        }
+        success.add(toResponseSlot(originalSlot));
     }
 
     /**
-     * 월 최대 근무 시간 초과 여부를 검증합니다.
-     * deleteSlots 반영 후 addSlots를 추가했을 때의 시간을 기준으로 계산합니다.
+     * 원본 범위를 단위 슬롯으로 분할해 중복·정원을 검증한 후 일괄 저장 목록에 추가한다.
+     * 하나라도 실패하면 원본 범위 전체를 실패로 처리한다.
      */
+    private void processAddSlot(
+            User user,
+            WorkScheduleSlotCommand originalSlot,
+            WorkScheduleSetting setting,
+            List<WorkScheduleChangeResponseDetail.Slot> success,
+            List<WorkScheduleChangeResponseDetail.Slot> failure,
+            List<ScheduleChange> changes,
+            List<WorkSchedule> toSave,
+            Map<LocalDate, List<WorkSchedule>> daySchedules,
+            Map<SlotKey, WorkSchedule> userScheduleMap,
+            Set<SlotKey> tentativeSlotKeys) {
+
+        int unitMinutes = setting.getMinWorkUnitMinutes();
+        List<WorkScheduleSlotCommand> unitSlots = WorkSlotUtils.splitIntoUnitSlots(
+                originalSlot.date(), originalSlot.start(), originalSlot.end(), unitMinutes);
+
+        CodeType statusCode = setting.isApplyPeriod(LocalDateTime.now()) ? CodeType.WS02 : CodeType.WS01;
+
+        // 모든 단위 슬롯을 먼저 검증
+        for (WorkScheduleSlotCommand unitSlot : unitSlots) {
+            SlotKey key = new SlotKey(unitSlot.date(), unitSlot.start(), unitSlot.end());
+
+            WorkSchedule existing = userScheduleMap.get(key);
+            boolean isDuplicate = (existing != null && !existing.getStatusCode().equals(CodeType.WS04))
+                    || tentativeSlotKeys.contains(key);
+            if (isDuplicate) {
+                failure.add(toResponseSlot(originalSlot));
+                return;
+            }
+
+            List<WorkSchedule> dayList = daySchedules.getOrDefault(unitSlot.date(), List.of());
+            if (!scheduleValidator.isScheduleInsertable(unitSlot, setting.getMaxConcurrentWorkers(), dayList)) {
+                failure.add(toResponseSlot(originalSlot));
+                return;
+            }
+        }
+
+        // 모두 통과 → 저장 목록에 추가
+        Workplace workplace = resolveWorkplace(user);
+        for (WorkScheduleSlotCommand unitSlot : unitSlots) {
+            SlotKey key = new SlotKey(unitSlot.date(), unitSlot.start(), unitSlot.end());
+            tentativeSlotKeys.add(key);
+
+            toSave.add(WorkSchedule.builder()
+                    .user(user)
+                    .setting(setting)
+                    .workplace(workplace)
+                    .date(unitSlot.date())
+                    .startTime(unitSlot.start())
+                    .endTime(unitSlot.end())
+                    .statusCode(statusCode)
+                    .createdBy(String.valueOf(user.getUserId()))
+                    .updatedBy(String.valueOf(user.getUserId()))
+                    .build());
+
+            if (statusCode.equals(CodeType.WS02)) {
+                changes.add(new ScheduleChange(true,
+                        LocalDateTime.of(unitSlot.date(), unitSlot.start()),
+                        LocalDateTime.of(unitSlot.date(), unitSlot.end())));
+            }
+        }
+        success.add(toResponseSlot(originalSlot));
+    }
+
     private void validateMonthlyLimit(
             Long userId,
             List<WorkScheduleSlotCommand> addSlots,
-            List<WorkScheduleSlotCommand> deleteSlots
-    ) {
-        if (addSlots.isEmpty()) {
-            return;
-        }
+            List<WorkScheduleSlotCommand> deleteSlots) {
+        if (addSlots.isEmpty()) return;
 
         YearMonth targetMonth = YearMonth.from(addSlots.get(0).date());
-
         LocalDate monthStart = targetMonth.atDay(1);
         LocalDate monthEnd = targetMonth.atEndOfMonth();
 
         List<WorkSchedule> currentSchedules =
                 workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(
-                        userId,
-                        monthStart,
-                        monthEnd,
-                        CodeType.WS04
-                );
+                        userId, monthStart, monthEnd, CodeType.WS04);
 
         long currentMinutes = currentSchedules.stream()
-                .mapToLong(schedule ->
-                        Duration.between(
-                                schedule.getStartTime(),
-                                schedule.getEndTime()
-                        ).toMinutes()
-                )
-                .sum();
+                .mapToLong(s -> Duration.between(s.getStartTime(), s.getEndTime()).toMinutes()).sum();
 
         long deleteMinutes = deleteSlots.stream()
-                .filter(slot -> YearMonth.from(slot.date()).equals(targetMonth))
-                .mapToLong(slot -> Duration.between(slot.start(), slot.end()).toMinutes())
-                .sum();
+                .filter(s -> YearMonth.from(s.date()).equals(targetMonth))
+                .mapToLong(s -> Duration.between(s.start(), s.end()).toMinutes()).sum();
 
         long addMinutes = addSlots.stream()
-                .filter(slot -> YearMonth.from(slot.date()).equals(targetMonth))
-                .mapToLong(slot -> Duration.between(slot.start(), slot.end()).toMinutes())
-                .sum();
+                .filter(s -> YearMonth.from(s.date()).equals(targetMonth))
+                .mapToLong(s -> Duration.between(s.start(), s.end()).toMinutes()).sum();
 
         long requestedMinutes = currentMinutes - deleteMinutes + addMinutes;
 
         if (requestedMinutes > MONTHLY_LIMIT_MINUTES) {
             throw new MonthlyWorkTimeExceededException(
                     MONTHLY_LIMIT_HOURS,
-                    (int) Math.ceil(requestedMinutes / 60.0)
-            );
+                    (int) Math.ceil(requestedMinutes / 60.0));
         }
     }
 
-    /**
-     * 삭제 요청 슬롯을 처리합니다.
-     * 일치하는 일정이 있으면 취소 처리하고, 없으면 실패 목록에 추가합니다.
-     */
-    private void deleteSlot(
-            Long userId,
-            WorkScheduleSlotCommand slot,
-            List<WorkScheduleChangeResponseDetail.Slot> success,
-            List<WorkScheduleChangeResponseDetail.Slot> failure,
-            List<ScheduleChange> changes
-    ) {
-        Optional<WorkSchedule> scheduleOptional =
-                workSchedulesRepository.findByUser_UserIdAndDateAndStartTimeAndEndTime(
-                        userId,
-                        slot.date(),
-                        slot.start(),
-                        slot.end()
-                );
-
-        if (scheduleOptional.isEmpty()) {
-            failure.add(toResponseSlot(slot));
-            return;
-        }
-
-        WorkSchedule schedule = scheduleOptional.get();
-
-        if (schedule.getStatusCode().equals(CodeType.WS04)) {
-            failure.add(toResponseSlot(slot));
-            return;
-        }
-
-        schedule.cancel(String.valueOf(userId));
-
-        success.add(toResponseSlot(slot));
-        changes.add(new ScheduleChange(
-                false,
-                slot.startDateTime(),
-                slot.endDateTime()
-        ));
-    }
-
-    /**
-     * 추가 요청 슬롯을 처리합니다.
-     * 동일한 일정이 이미 있거나 동시 근무 제한을 초과하면 실패 목록에 추가합니다.
-     */
-    private void addSlot(
-            User user,
-            WorkScheduleSlotCommand slot,
-            List<WorkScheduleChangeResponseDetail.Slot> success,
-            List<WorkScheduleChangeResponseDetail.Slot> failure,
-            List<ScheduleChange> changes
-    ) {
-        boolean exists =
-                workSchedulesRepository.existsByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeNot(
-                        user.getUserId(),
-                        slot.date(),
-                        slot.start(),
-                        slot.end(),
-                        CodeType.WS04
-                );
-
-        if (exists) {
-            failure.add(toResponseSlot(slot));
-            return;
-        }
-
-        WorkScheduleSetting setting = workScheduleSettingService.getRequiredSetting(
-                user.getOrganizationId(),
-                slot.date().getYear(),
-                slot.date().getMonthValue()
-        );
-
-        if (!scheduleValidator.isScheduleInsertable(slot, setting)) {
-            failure.add(toResponseSlot(slot));
-            return;
-        }
-
-        CodeType statusCode = setting.isApplyPeriod(LocalDateTime.now())
-                ? CodeType.WS02
-                : CodeType.WS01;
-
-        WorkSchedule workSchedule = WorkSchedule.builder()
-                .user(user)
-                .setting(setting)
-                .workplace(resolveWorkplace(user))
-                .date(slot.date())
-                .startTime(slot.start())
-                .endTime(slot.end())
-                .statusCode(statusCode)
-                .createdBy(String.valueOf(user.getUserId()))
-                .updatedBy(String.valueOf(user.getUserId()))
-                .build();
-
-        workSchedulesRepository.save(workSchedule);
-
-        success.add(toResponseSlot(slot));
-
-        if (statusCode.equals(CodeType.WS02)) {
-            changes.add(new ScheduleChange(
-                    true,
-                    slot.startDateTime(),
-                    slot.endDateTime()
-            ));
-        }
-    }
-
-    /**
-     * User 기준으로 근무지를 조회합니다.
-     * User 엔티티 구조에 맞게 이 부분만 수정하면 됩니다.
-     */
     private Workplace resolveWorkplace(User user) {
         return workplaceRepository.findFirstByOrganizationId(user.getOrganizationId())
                 .orElseThrow(() -> CustomException.of(ScheduleErrorCode.SCHEDULE_FAILURE));
     }
 
-    /**
-     * Application Slot Command를 응답 Slot으로 변환합니다.
-     */
-    private WorkScheduleChangeResponseDetail.Slot toResponseSlot(
-            WorkScheduleSlotCommand slot
-    ) {
-        return new WorkScheduleChangeResponseDetail.Slot(
-                slot.startDateTime(),
-                slot.endDateTime()
-        );
+    private WorkScheduleChangeResponseDetail.Slot toResponseSlot(WorkScheduleSlotCommand slot) {
+        return new WorkScheduleChangeResponseDetail.Slot(slot.startDateTime(), slot.endDateTime());
     }
 
-    /**
-     * 특정 사용자의 연/월별 근무 일정 조회
-     */
     @Transactional(readOnly = true)
-    public List<WorkScheduleResponse> getWorkSchedules(
-            Long userId,
-            Integer year,
-            Integer month
-    ) {
+    public List<WorkScheduleResponse> getWorkSchedules(Long userId, Integer year, Integer month) {
         YearMonth yearMonth = YearMonth.of(year, month);
-
         return workSchedulesRepository
                 .findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(
-                        userId,
-                        yearMonth.atDay(1),
-                        yearMonth.atEndOfMonth(),
-                        CodeType.WS04
-                )
-                .stream()
-                .map(WorkScheduleResponse::from)
-                .toList();
+                        userId, yearMonth.atDay(1), yearMonth.atEndOfMonth(), CodeType.WS04)
+                .stream().map(WorkScheduleResponse::from).toList();
     }
 
-    /**
-     * 특정 사용자의 연/월별 근무 이력 조회
-     */
     @Transactional(readOnly = true)
     public List<WorkScheduleHistoryResponse> getWorkScheduleHistory(
-            Long userId,
-            Integer year,
-            Integer month
-    ) {
+            Long userId, Integer year, Integer month) {
         YearMonth yearMonth = YearMonth.of(year, month);
-
-        List<WorkSchedule> schedules =
-                workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(
-                        userId,
-                        yearMonth.atDay(1),
-                        yearMonth.atEndOfMonth(),
-                        CodeType.WS04
-                );
+        List<WorkSchedule> schedules = workSchedulesRepository
+                .findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(
+                        userId, yearMonth.atDay(1), yearMonth.atEndOfMonth(), CodeType.WS04);
 
         List<WorkScheduleHistoryResponse> historyList = new ArrayList<>();
-
         for (WorkSchedule schedule : schedules) {
             List<WorkAttendance> attendances =
                     workAttendanceRepository.findBySchedule_ScheduleId(schedule.getScheduleId());
 
             Optional<WorkAttendance> checkIn = attendances.stream()
-                    .filter(a -> a.getCheckTypeCode() == CodeType.CT01)
-                    .findFirst();
-
+                    .filter(a -> a.getCheckTypeCode() == CodeType.CT01).findFirst();
             Optional<WorkAttendance> checkOut = attendances.stream()
-                    .filter(a -> a.getCheckTypeCode() == CodeType.CT02)
-                    .findFirst();
+                    .filter(a -> a.getCheckTypeCode() == CodeType.CT02).findFirst();
 
-            LocalDateTime actualStart = checkIn
-                    .map(WorkAttendance::getCheckTime)
-                    .orElse(null);
-
-            LocalDateTime actualEnd = checkOut
-                    .map(WorkAttendance::getCheckTime)
-                    .orElse(null);
-
-            Long duration = null;
-
-            if (actualStart != null && actualEnd != null) {
-                duration = Duration.between(actualStart, actualEnd).toMinutes();
-            }
+            LocalDateTime actualStart = checkIn.map(WorkAttendance::getCheckTime).orElse(null);
+            LocalDateTime actualEnd = checkOut.map(WorkAttendance::getCheckTime).orElse(null);
+            Long duration = (actualStart != null && actualEnd != null)
+                    ? Duration.between(actualStart, actualEnd).toMinutes() : null;
 
             historyList.add(WorkScheduleHistoryResponse.builder()
                     .id(schedule.getScheduleId())
@@ -424,77 +406,48 @@ public class ScheduleService {
                     .workDurationMinutes(duration)
                     .build());
         }
-
         historyList.sort(Comparator.comparing(WorkScheduleHistoryResponse::getStart));
-
         return historyList;
     }
 
-    /**
-     * 특정 근무 일정 상세 조회
-     */
     @Transactional(readOnly = true)
-    public WorkScheduleResponse getWorkSchedule(
-            Long userId,
-            Long scheduleId
-    ) {
+    public WorkScheduleResponse getWorkSchedule(Long userId, Long scheduleId) {
         WorkSchedule schedule = workSchedulesRepository.findById(scheduleId)
                 .orElseThrow(() -> CustomException.of(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
-
         if (!schedule.getUser().getUserId().equals(userId)) {
             throw CustomException.of(ScheduleErrorCode.UNAUTHORIZED_ACCESS);
         }
-
         return WorkScheduleResponse.from(schedule);
     }
 
-    /**
-     * 모든 접속자에게 스케줄 변경 알림을 전송합니다.
-     */
     private void broadcastScheduleUpdate(List<ScheduleChange> changes) {
-        if (changes.isEmpty()) {
-            return;
-        }
+        if (changes.isEmpty()) return;
 
         List<ScheduleUpdateMessage.SlotUpdateInfo> updates = new ArrayList<>();
-
         for (ScheduleChange change : changes) {
             LocalDateTime current = change.getStart();
-            LocalDateTime end = change.getEnd();
-
-            while (current.isBefore(end)) {
+            while (current.isBefore(change.getEnd())) {
                 updates.add(ScheduleUpdateMessage.SlotUpdateInfo.builder()
                         .isAdd(change.isAdd())
                         .slotStartTime(current)
                         .build());
-                current = current.plusMinutes(30);
+                current = current.plusMinutes(SLOT_MINUTES);
             }
         }
 
-        ScheduleUpdateMessage message = ScheduleUpdateMessage.builder()
-                .type("SCHEDULE_UPDATED")
-                .updates(updates)
-                .build();
-
-        messagingTemplate.convertAndSend("/topic/schedule-updates", message);
+        messagingTemplate.convertAndSend("/topic/schedule-updates",
+                ScheduleUpdateMessage.builder().type("SCHEDULE_UPDATED").updates(updates).build());
     }
 
     @Transactional(readOnly = true)
     public WorkScheduleMonthlyLimitResponse getMonthlyLimit(
-            Long organizationId,
-            Integer year,
-            Integer month
-    ) {
+            Long organizationId, Integer year, Integer month) {
         validateYearMonth(year, month);
         WorkScheduleSetting setting = workScheduleSettingService.getRequiredSetting(organizationId, year, month);
         Integer maxConcurrent = setting.getMaxConcurrentWorkers() != null
-                ? setting.getMaxConcurrentWorkers()
-                : DEFAULT_SETTING_MAX_CONCURRENT;
+                ? setting.getMaxConcurrentWorkers() : DEFAULT_SETTING_MAX_CONCURRENT;
         return WorkScheduleMonthlyLimitResponse.builder()
-                .scheduleYear(year)
-                .scheduleMonth(month)
-                .maxConcurrentWorkers(maxConcurrent)
-                .build();
+                .scheduleYear(year).scheduleMonth(month).maxConcurrentWorkers(maxConcurrent).build();
     }
 
     @Transactional
@@ -512,61 +465,87 @@ public class ScheduleService {
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));
 
+        // 단위 정렬 검증을 위해 관련 setting 로드 (Optional)
+        Map<YearMonth, WorkScheduleSetting> settingsForEdit = new HashMap<>();
+        addSlots.stream().map(s -> YearMonth.from(s.date())).distinct().forEach(ym ->
+                workScheduleSettingService.getSetting(user.getOrganizationId(), ym.getYear(), ym.getMonthValue())
+                        .ifPresent(s -> settingsForEdit.put(ym, s)));
+        deleteSlots.stream().map(s -> YearMonth.from(s.date())).distinct().forEach(ym -> {
+            if (!settingsForEdit.containsKey(ym)) {
+                workScheduleSettingService.getSetting(user.getOrganizationId(), ym.getYear(), ym.getMonthValue())
+                        .ifPresent(s -> settingsForEdit.put(ym, s));
+            }
+        });
+
+        validateEditSlotUnitAlignment(addSlots, settingsForEdit);
+        validateEditSlotUnitAlignment(deleteSlots, settingsForEdit);
+
         validateMonthlyLimitForEdit(userId, user.getOrganizationId(), addSlots, deleteSlots);
 
         WorkChangeRequest changeRequest = WorkChangeRequest.builder()
-                .user(user)
-                .reason(request.reason())
-                .statusCode(CodeType.CS01)
-                .createdBy(userId)
-                .updatedBy(userId)
-                .build();
+                .user(user).reason(request.reason()).statusCode(CodeType.CS01)
+                .createdBy(userId).updatedBy(userId).build();
         workChangeRequestRepository.save(changeRequest);
 
         for (WorkScheduleEditRequest.Slot slot : deleteSlots) {
-            WorkSchedule schedule = workSchedulesRepository
-                    .findByUser_UserIdAndDateAndStartTimeAndEndTime(userId, slot.date(), slot.start(), slot.end())
-                    .filter(s -> !s.getStatusCode().equals(CodeType.WS04))
-                    .orElseThrow(() -> CustomException.of(ScheduleErrorCode.DELETE_SCHEDULE_NOT_FOUND));
-
+            WorkScheduleSetting setting = settingsForEdit.get(YearMonth.from(slot.date()));
+            int unitMinutes = setting != null ? setting.getMinWorkUnitMinutes() : SLOT_MINUTES;
+            for (WorkScheduleSlotCommand unitSlot : WorkSlotUtils.splitIntoUnitSlots(
+                    slot.date(), slot.start(), slot.end(), unitMinutes)) {
+                workSchedulesRepository
+                        .findByUser_UserIdAndDateAndStartTimeAndEndTime(
+                                userId, unitSlot.date(), unitSlot.start(), unitSlot.end())
+                        .filter(s -> !s.getStatusCode().equals(CodeType.WS04))
+                        .orElseThrow(() -> CustomException.of(ScheduleErrorCode.DELETE_SCHEDULE_NOT_FOUND));
+            }
+            // 이력 보존을 위해 원본 범위를 그대로 저장한다.
+            // schedule FK는 범위 분할로 다수 슬롯이 되므로 null 처리.
+            // 어드민 승인 처리(AdminWorkChangeRequestProcessService)도 함께 수정 필요 — 리포트 참고.
             workChangeRequestItemRepository.save(WorkChangeRequestItem.builder()
-                    .request(changeRequest)
-                    .changeTypeCode(CodeType.CR02)
-                    .schedule(schedule)
-                    .date(slot.date())
-                    .startTime(slot.start())
-                    .endTime(slot.end())
-                    .build());
+                    .request(changeRequest).changeTypeCode(CodeType.CR02)
+                    .schedule(null)
+                    .date(slot.date()).startTime(slot.start()).endTime(slot.end()).build());
         }
 
         for (WorkScheduleEditRequest.Slot slot : addSlots) {
             workChangeRequestItemRepository.save(WorkChangeRequestItem.builder()
-                    .request(changeRequest)
-                    .changeTypeCode(CodeType.CR01)
+                    .request(changeRequest).changeTypeCode(CodeType.CR01)
                     .schedule(null)
-                    .date(slot.date())
-                    .startTime(slot.start())
-                    .endTime(slot.end())
-                    .build());
+                    .date(slot.date()).startTime(slot.start()).endTime(slot.end()).build());
         }
 
         return WorkScheduleEditResponse.builder()
                 .requestId(changeRequest.getRequestId())
-                .status(CodeType.CS01.getCodeName())
-                .build();
+                .status(CodeType.CS01.getCodeName()).build();
+    }
+
+    private void validateEditSlotUnitAlignment(
+            List<WorkScheduleEditRequest.Slot> slots,
+            Map<YearMonth, WorkScheduleSetting> settingsByMonth) {
+        for (WorkScheduleEditRequest.Slot slot : slots) {
+            WorkScheduleSetting setting = settingsByMonth.get(YearMonth.from(slot.date()));
+            if (setting == null) continue;
+            int unitMinutes = setting.getMinWorkUnitMinutes();
+            int startTotalMinutes = slot.start().getHour() * 60 + slot.start().getMinute();
+            if (startTotalMinutes % unitMinutes != 0) {
+                throw CustomException.of(ScheduleErrorCode.INVALID_SLOT_UNIT);
+            }
+            long durationMinutes = Duration.between(slot.start(), slot.end()).toMinutes();
+            if (durationMinutes <= 0 || durationMinutes % unitMinutes != 0) {
+                throw CustomException.of(ScheduleErrorCode.INVALID_SLOT_UNIT);
+            }
+        }
     }
 
     private void validateMonthlyLimitForEdit(
-            Long userId,
-            Long organizationId,
+            Long userId, Long organizationId,
             List<WorkScheduleEditRequest.Slot> addSlots,
-            List<WorkScheduleEditRequest.Slot> deleteSlots
-    ) {
+            List<WorkScheduleEditRequest.Slot> deleteSlots) {
         if (addSlots.isEmpty()) return;
 
         YearMonth targetMonth = YearMonth.from(addSlots.get(0).date());
-        Optional<WorkScheduleSetting> settingOpt = workScheduleSettingService
-                .getSetting(organizationId, targetMonth.getYear(), targetMonth.getMonthValue());
+        Optional<WorkScheduleSetting> settingOpt =
+                workScheduleSettingService.getSetting(organizationId, targetMonth.getYear(), targetMonth.getMonthValue());
         if (settingOpt.isEmpty()) return;
 
         WorkScheduleSetting setting = settingOpt.get();
@@ -590,19 +569,13 @@ public class ScheduleService {
 
         if (requestedMinutes > limitMinutes) {
             throw new MonthlyWorkTimeExceededException(
-                    limitMinutes / 60,
-                    (int) Math.ceil(requestedMinutes / 60.0)
-            );
+                    limitMinutes / 60, (int) Math.ceil(requestedMinutes / 60.0));
         }
     }
 
     @Transactional(readOnly = true)
     public WorkMonthlyScheduleResponse getMonthlyScheduleView(
-            Long userId,
-            Long organizationId,
-            Integer year,
-            Integer month
-    ) {
+            Long userId, Long organizationId, Integer year, Integer month) {
         validateYearMonth(year, month);
         WorkScheduleSetting setting = workScheduleSettingService.getRequiredSetting(organizationId, year, month);
         YearMonth yearMonth = YearMonth.of(year, month);
@@ -613,33 +586,24 @@ public class ScheduleService {
         List<WorkMonthlyScheduleResponse.DaySchedule> days = buildDaySlotList(monthStart, monthEnd, ctx);
 
         return WorkMonthlyScheduleResponse.builder()
-                .year(year)
-                .month(month)
+                .year(year).month(month)
                 .maxConcurrentWorkers(setting.getMaxConcurrentWorkers())
                 .totalLimitHours(setting.getMonthlyRequiredMinutes() / 60)
-                .usedHours(ctx.usedHours())
-                .days(days)
-                .build();
+                .usedHours(ctx.usedHours()).days(days).build();
     }
 
     @Transactional(readOnly = true)
     public WorkScheduleSummaryResponse getScheduleSummary(
-            Long userId,
-            Long organizationId,
-            LocalDate startDate,
-            LocalDate endDate
-    ) {
+            Long userId, Long organizationId, LocalDate startDate, LocalDate endDate) {
         validateSummaryDateRange(startDate, endDate);
 
         Optional<WorkScheduleSetting> settingOpt =
                 workScheduleSettingService.getSetting(organizationId, startDate.getYear(), startDate.getMonthValue());
 
-        // 조회 기간(startDate~endDate) 근무 시간 합산 — week.usedHours
         long weekUsedMinutes = workSchedulesRepository
                 .findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(userId, startDate, endDate, ACTIVE_STATUSES)
                 .stream().mapToLong(s -> Duration.between(s.getStartTime(), s.getEndTime()).toMinutes()).sum();
 
-        // 해당 월 전체 근무 시간 합산 — month.usedHours
         YearMonth yearMonth = YearMonth.from(startDate);
         LocalDate monthStart = yearMonth.atDay(1);
         LocalDate monthEnd = yearMonth.atEndOfMonth();
@@ -647,44 +611,28 @@ public class ScheduleService {
                 .findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(userId, monthStart, monthEnd, ACTIVE_STATUSES)
                 .stream().mapToLong(s -> Duration.between(s.getStartTime(), s.getEndTime()).toMinutes()).sum();
 
-        // 한도: setting 없으면 0
         int weekLimitHours = settingOpt
-                .map(s -> s.getWeeklyMaxMinutes() != null ? s.getWeeklyMaxMinutes() / 60 : 0)
-                .orElse(0);
-        // monthly_required_minutes → limitHours (컬럼명은 'required'지만 진행률 표시 통일을 위해 limitHours로 응답)
-        int monthLimitHours = settingOpt
-                .map(s -> s.getMonthlyRequiredMinutes() / 60)
-                .orElse(0);
-
+                .map(s -> s.getWeeklyMaxMinutes() != null ? s.getWeeklyMaxMinutes() / 60 : 0).orElse(0);
+        int monthLimitHours = settingOpt.map(s -> s.getMonthlyRequiredMinutes() / 60).orElse(0);
         int weekNumber = WorkWeekUtils.weekOfMonth(startDate);
 
         return WorkScheduleSummaryResponse.builder()
-                .startDate(startDate)
-                .endDate(endDate)
+                .startDate(startDate).endDate(endDate)
                 .week(WorkScheduleSummaryResponse.PeriodSummary.builder()
                         .label(weekNumber + "주차")
-                        .usedHours((int) (weekUsedMinutes / 60))
-                        .limitHours(weekLimitHours)
-                        .build())
+                        .usedHours((int) (weekUsedMinutes / 60)).limitHours(weekLimitHours).build())
                 .month(WorkScheduleSummaryResponse.PeriodSummary.builder()
                         .label(startDate.getMonthValue() + "월 전체")
-                        .usedHours((int) (monthUsedMinutes / 60))
-                        .limitHours(monthLimitHours)
-                        .build())
+                        .usedHours((int) (monthUsedMinutes / 60)).limitHours(monthLimitHours).build())
                 .build();
     }
 
     @Transactional(readOnly = true)
     public WorkScheduleRangeResponse getScheduleRangeView(
-            Long userId,
-            Long organizationId,
-            LocalDate startDate,
-            LocalDate endDate
-    ) {
+            Long userId, Long organizationId, LocalDate startDate, LocalDate endDate) {
         validateDateRange(startDate, endDate);
         WorkScheduleSetting setting = workScheduleSettingService
-                .getSetting(organizationId, startDate.getYear(), startDate.getMonthValue())
-                .orElse(null);
+                .getSetting(organizationId, startDate.getYear(), startDate.getMonthValue()).orElse(null);
 
         YearMonth yearMonth = YearMonth.from(startDate);
         LocalDate monthStart = yearMonth.atDay(1);
@@ -697,25 +645,18 @@ public class ScheduleService {
         Integer totalLimitHours = setting != null ? setting.getMonthlyRequiredMinutes() / 60 : null;
 
         return WorkScheduleRangeResponse.builder()
-                .startDate(startDate)
-                .endDate(endDate)
-                .maxConcurrentWorkers(maxConcurrent)
-                .totalLimitHours(totalLimitHours)
-                .usedHours(ctx.usedHours())
-                .days(days)
-                .build();
+                .startDate(startDate).endDate(endDate)
+                .maxConcurrentWorkers(maxConcurrent).totalLimitHours(totalLimitHours)
+                .usedHours(ctx.usedHours()).days(days).build();
     }
 
     private Set<SlotKey> buildItemSlots(
             Long userId, CodeType changeTypeCode, LocalDate startDate, LocalDate endDate) {
         Set<SlotKey> slots = new HashSet<>();
-        List<WorkChangeRequestItem> items =
-                workChangeRequestItemRepository
-                        .findByRequest_User_UserIdAndRequest_StatusCodeAndChangeTypeCodeAndDateBetween(
-                                userId, CodeType.CS01, changeTypeCode, startDate, endDate);
-        for (WorkChangeRequestItem item : items) {
-            slots.addAll(expandToSlots(item.getDate(), item.getStartTime(), item.getEndTime()));
-        }
+        workChangeRequestItemRepository
+                .findByRequest_User_UserIdAndRequest_StatusCodeAndChangeTypeCodeAndDateBetween(
+                        userId, CodeType.CS01, changeTypeCode, startDate, endDate)
+                .forEach(item -> slots.addAll(expandToSlots(item.getDate(), item.getStartTime(), item.getEndTime())));
         return slots;
     }
 
@@ -726,36 +667,26 @@ public class ScheduleService {
     }
 
     private void validateDateRange(LocalDate startDate, LocalDate endDate) {
-        if (startDate.isAfter(endDate)) {
-            throw CustomException.of(ScheduleErrorCode.INVALID_DATE_RANGE);
-        }
-        if (!YearMonth.from(startDate).equals(YearMonth.from(endDate))) {
+        if (startDate.isAfter(endDate)) throw CustomException.of(ScheduleErrorCode.INVALID_DATE_RANGE);
+        if (!YearMonth.from(startDate).equals(YearMonth.from(endDate)))
             throw CustomException.of(ScheduleErrorCode.CROSS_MONTH_RANGE_NOT_ALLOWED);
-        }
     }
 
     private void validateSummaryDateRange(LocalDate startDate, LocalDate endDate) {
-        if (startDate.isAfter(endDate)) {
-            throw CustomException.of(ScheduleErrorCode.INVALID_DATE_RANGE);
-        }
-        if (!YearMonth.from(startDate).equals(YearMonth.from(endDate))) {
+        if (startDate.isAfter(endDate)) throw CustomException.of(ScheduleErrorCode.INVALID_DATE_RANGE);
+        if (!YearMonth.from(startDate).equals(YearMonth.from(endDate)))
             throw CustomException.of(ScheduleErrorCode.CROSS_MONTH_RANGE_NOT_ALLOWED);
-        }
-        if (!WorkWeekUtils.isSameWeek(startDate, endDate)) {
+        if (!WorkWeekUtils.isSameWeek(startDate, endDate))
             throw CustomException.of(ScheduleErrorCode.CROSS_WEEK_RANGE_NOT_ALLOWED);
-        }
     }
 
     private SlotViewContext buildSlotViewContext(
-            Long userId,
-            WorkScheduleSetting setting,
-            LocalDate queryStart,
-            LocalDate queryEnd,
-            LocalDate monthStart,
-            LocalDate monthEnd
-    ) {
+            Long userId, WorkScheduleSetting setting,
+            LocalDate queryStart, LocalDate queryEnd,
+            LocalDate monthStart, LocalDate monthEnd) {
         Map<SlotKey, Integer> currentCountMap = new HashMap<>();
-        for (WorkSchedule s : workSchedulesRepository.findAllByDateBetweenAndStatusCodeIn(queryStart, queryEnd, ACTIVE_STATUSES)) {
+        for (WorkSchedule s : workSchedulesRepository.findAllByDateBetweenAndStatusCodeIn(
+                queryStart, queryEnd, ACTIVE_STATUSES)) {
             for (SlotKey k : expandToSlots(s.getDate(), s.getStartTime(), s.getEndTime()))
                 currentCountMap.merge(k, 1, Integer::sum);
         }
@@ -770,7 +701,8 @@ public class ScheduleService {
 
         Set<SlotKey> unavailableSlots = new HashSet<>();
         if (setting != null) {
-            for (WorkUnavailableTime u : workUnavailableTimeRepository.findBySettingAndDateBetween(setting, queryStart, queryEnd))
+            for (WorkUnavailableTime u : workUnavailableTimeRepository.findBySettingAndDateBetween(
+                    setting, queryStart, queryEnd))
                 unavailableSlots.addAll(expandToSlots(u.getDate(), u.getStartTime(), u.getEndTime()));
         }
 
@@ -778,15 +710,12 @@ public class ScheduleService {
                 .findAllByUser_UserIdAndDateBetweenAndStatusCodeIn(userId, monthStart, monthEnd, ACTIVE_STATUSES)
                 .stream().mapToLong(s -> Duration.between(s.getStartTime(), s.getEndTime()).toMinutes()).sum();
 
-        return new SlotViewContext(currentCountMap, myScheduleSlots, pendingDeleteSlots, pendingAddSlots,
-                unavailableSlots, (int) (usedMinutes / 60));
+        return new SlotViewContext(currentCountMap, myScheduleSlots, pendingDeleteSlots,
+                pendingAddSlots, unavailableSlots, (int) (usedMinutes / 60));
     }
 
     private List<WorkMonthlyScheduleResponse.DaySchedule> buildDaySlotList(
-            LocalDate startDate,
-            LocalDate endDate,
-            SlotViewContext ctx
-    ) {
+            LocalDate startDate, LocalDate endDate, SlotViewContext ctx) {
         List<WorkMonthlyScheduleResponse.DaySchedule> days = new ArrayList<>();
         for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
             List<WorkMonthlyScheduleResponse.SlotInfo> slots = new ArrayList<>();
@@ -795,12 +724,10 @@ public class ScheduleService {
                 LocalTime next = current.plusMinutes(SLOT_MINUTES);
                 SlotKey key = new SlotKey(date, current, next);
                 slots.add(WorkMonthlyScheduleResponse.SlotInfo.builder()
-                        .start(current)
-                        .end(next)
+                        .start(current).end(next)
                         .status(resolveSlotStatus(key, ctx.myScheduleSlots(), ctx.pendingDeleteSlots(),
                                 ctx.pendingAddSlots(), ctx.unavailableSlots()))
-                        .currentCount(ctx.currentCountMap().getOrDefault(key, 0))
-                        .build());
+                        .currentCount(ctx.currentCountMap().getOrDefault(key, 0)).build());
                 current = next;
             }
             days.add(WorkMonthlyScheduleResponse.DaySchedule.builder().date(date).slots(slots).build());
@@ -808,13 +735,8 @@ public class ScheduleService {
         return days;
     }
 
-    private String resolveSlotStatus(
-            SlotKey key,
-            Set<SlotKey> myScheduleSlots,
-            Set<SlotKey> pendingDeleteSlots,
-            Set<SlotKey> pendingAddSlots,
-            Set<SlotKey> unavailableSlots
-    ) {
+    private String resolveSlotStatus(SlotKey key, Set<SlotKey> myScheduleSlots,
+            Set<SlotKey> pendingDeleteSlots, Set<SlotKey> pendingAddSlots, Set<SlotKey> unavailableSlots) {
         if (myScheduleSlots.contains(key)) return "MY_SCHEDULE";
         if (pendingDeleteSlots.contains(key)) return "PENDING_DELETE";
         if (pendingAddSlots.contains(key)) return "PENDING_ADD";
@@ -826,7 +748,7 @@ public class ScheduleService {
         List<SlotKey> slots = new ArrayList<>();
         LocalTime current = startTime;
         while (current.isBefore(endTime)) {
-            LocalTime next = current.plusMinutes(30);
+            LocalTime next = current.plusMinutes(SLOT_MINUTES);
             slots.add(new SlotKey(date, current, next));
             current = next;
         }
@@ -839,8 +761,7 @@ public class ScheduleService {
             Set<SlotKey> pendingDeleteSlots,
             Set<SlotKey> pendingAddSlots,
             Set<SlotKey> unavailableSlots,
-            int usedHours
-    ) {}
+            int usedHours) {}
 
     private record SlotKey(LocalDate date, LocalTime startTime, LocalTime endTime) {}
 

--- a/src/main/java/com/better/CommuteMate/schedule/application/ScheduleValidator.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/ScheduleValidator.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -22,47 +23,46 @@ public class ScheduleValidator {
     private final WorkSchedulesRepository workSchedulesRepository;
 
     /**
-     * 변경사항 API의 슬롯 기준으로 동시 근무 제한을 검증합니다.
-     * addSlots 처리 시 사용합니다.
+     * 어드민 승인 처리 등 DB에서 직접 조회가 필요한 경우에 사용합니다.
      */
     public boolean isScheduleInsertable(
             WorkScheduleSlotCommand slot,
             WorkScheduleSetting setting
     ) {
-        return isScheduleInsertable(
-                slot.date(),
-                slot.start(),
-                slot.end(),
-                setting.getMaxConcurrentWorkers()
-        );
+        List<WorkSchedule> daySchedules = workSchedulesRepository.findAllByDate(slot.date());
+        return isScheduleInsertable(slot.start(), slot.end(),
+                setting.getMaxConcurrentWorkers(), daySchedules);
     }
 
     /**
-     * 해당 날짜, 시작 시간, 종료 시간을 기준으로 동시 근무 제한을 검증합니다.
+     * 미리 조회한 해당 날짜 전체 근무 목록으로 동시 근무 제한을 검증합니다.
+     * changeWorkSchedules에서 배치 처리 시 사용합니다.
      */
+    public boolean isScheduleInsertable(
+            WorkScheduleSlotCommand slot,
+            int maxConcurrentWorkers,
+            List<WorkSchedule> preloadedDaySchedules
+    ) {
+        return isScheduleInsertable(slot.start(), slot.end(),
+                maxConcurrentWorkers, preloadedDaySchedules);
+    }
+
     private boolean isScheduleInsertable(
-            LocalDate date,
             LocalTime startTime,
             LocalTime endTime,
-            int maxConcurrentWorkers
+            int maxConcurrentWorkers,
+            List<WorkSchedule> daySchedules
     ) {
-        List<WorkSchedule> daySchedules = workSchedulesRepository.findAllByDate(date);
-
+        Set<CodeType> activeStatuses = Set.of(CodeType.WS01, CodeType.WS02);
         LocalTime currentCheckPoint = startTime.plusMinutes(15);
 
         while (currentCheckPoint.isBefore(endTime)) {
             LocalTime finalCheckPoint = currentCheckPoint;
 
             long overlappingCount = daySchedules.stream()
-                    .filter(schedule -> !schedule.getStatusCode().equals(CodeType.WS04))
-                    .filter(schedule ->
-                            schedule.getStatusCode().equals(CodeType.WS01)
-                                    || schedule.getStatusCode().equals(CodeType.WS02)
-                    )
-                    .filter(schedule ->
-                            schedule.getStartTime().isBefore(finalCheckPoint)
-                                    && schedule.getEndTime().isAfter(finalCheckPoint)
-                    )
+                    .filter(s -> activeStatuses.contains(s.getStatusCode()))
+                    .filter(s -> s.getStartTime().isBefore(finalCheckPoint)
+                            && s.getEndTime().isAfter(finalCheckPoint))
                     .count();
 
             if (overlappingCount >= maxConcurrentWorkers) {

--- a/src/main/java/com/better/CommuteMate/schedule/application/WorkSlotUtils.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/WorkSlotUtils.java
@@ -1,0 +1,33 @@
+package com.better.CommuteMate.schedule.application;
+
+import com.better.CommuteMate.schedule.application.dtos.WorkScheduleSlotCommand;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 근무 슬롯 분할 유틸.
+ * apply·edit·어드민 승인 처리에서 재사용한다.
+ */
+public final class WorkSlotUtils {
+
+    private WorkSlotUtils() {}
+
+    /**
+     * 지정한 시간 범위를 unitMinutes 단위로 분할해 단위 슬롯 목록을 반환한다.
+     * 예: 09:00~11:00, unitMinutes=30 → [09:00~09:30, 09:30~10:00, 10:00~10:30, 10:30~11:00]
+     */
+    public static List<WorkScheduleSlotCommand> splitIntoUnitSlots(
+            LocalDate date, LocalTime start, LocalTime end, int unitMinutes) {
+        List<WorkScheduleSlotCommand> slots = new ArrayList<>();
+        LocalTime current = start;
+        while (current.isBefore(end)) {
+            LocalTime next = current.plusMinutes(unitMinutes);
+            slots.add(new WorkScheduleSlotCommand(date, current, next));
+            current = next;
+        }
+        return slots;
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 
 @Tag(name = "사용자 근무 일정", description = "사용자 근무 일정 신청 및 조회 API")
+@SecurityRequirement(name = "JWT")
 @RestController
 @RequestMapping("/api/v1/work-schedules")
 @RequiredArgsConstructor

--- a/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
@@ -76,6 +76,15 @@ public class WorkScheduleController {
                                     {"isSuccess":false,"message":"신청하신 일정이 모두 실패하였습니다.","details":{"success":[],"failure":[{"start":"2026-04-07T09:00:00","end":"2026-04-07T10:00:00"}]}}
                                     """)
                     })),
+            @ApiResponse(responseCode = "400", description = "잘못된 근무 단위 요청",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "최소 근무 단위 미준수", value = """
+                                    {"isSuccess":false,"message":"근무 시간은 최소 근무 단위 기준으로 신청해야 합니다.","details":null}
+                                    """),
+                            @ExampleObject(name = "최소 근무 시간 미충족", value = """
+                                    {"isSuccess":false,"message":"1회 최소 근무 시간(2시간)을 충족하지 못했습니다.","details":null}
+                                    """)
+                    })),
             @ApiResponse(responseCode = "404", description = "해당 연월의 스케줄 설정 없음",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = """
@@ -256,6 +265,11 @@ public class WorkScheduleController {
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(name = "수정 요청 성공", value = """
                                     {"isSuccess":true,"message":"수정 요청이 제출되었습니다. 승인 후 시간표에 반영됩니다.","details":{"requestId":123,"status":"PENDING"}}
+                                    """))),
+            @ApiResponse(responseCode = "400", description = "잘못된 근무 단위 요청",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {"isSuccess":false,"message":"근무 시간은 최소 근무 단위 기준으로 신청해야 합니다.","details":null}
                                     """))),
             @ApiResponse(responseCode = "422", description = "월 최대 근무 시간 초과",
                     content = @Content(mediaType = "application/json",

--- a/src/test/java/com/better/CommuteMate/schedule/application/ScheduleServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/schedule/application/ScheduleServiceTest.java
@@ -11,6 +11,8 @@ import com.better.CommuteMate.domain.workchangerequest.repository.WorkChangeRequ
 import com.better.CommuteMate.domain.workchangerequest.repository.WorkChangeRequestRepository;
 import com.better.CommuteMate.domain.workplace.entity.Workplace;
 import com.better.CommuteMate.domain.workplace.repository.WorkplaceRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
 import com.better.CommuteMate.schedule.application.dtos.WorkScheduleChangeCommand;
 import com.better.CommuteMate.schedule.application.dtos.WorkScheduleChangeResultCommand;
 import com.better.CommuteMate.schedule.application.dtos.WorkScheduleSlotCommand;
@@ -31,6 +33,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,88 +43,80 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ScheduleServiceTest {
 
-    @Mock
-    private WorkSchedulesRepository workSchedulesRepository;
-    @Mock
-    private WorkAttendanceRepository workAttendanceRepository;
-    @Mock
-    private WorkChangeRequestItemRepository workChangeRequestItemRepository;
-    @Mock
-    private WorkChangeRequestRepository workChangeRequestRepository;
-    @Mock
-    private WorkUnavailableTimeRepository workUnavailableTimeRepository;
-    @Mock
-    private UserRepository userRepository;
-    @Mock
-    private WorkplaceRepository workplaceRepository;
-    @Mock
-    private ScheduleValidator scheduleValidator;
-    @Mock
-    private WorkScheduleSettingService workScheduleSettingService;
-    @Mock
-    private SimpMessagingTemplate messagingTemplate;
+    @Mock private WorkSchedulesRepository workSchedulesRepository;
+    @Mock private WorkAttendanceRepository workAttendanceRepository;
+    @Mock private WorkChangeRequestItemRepository workChangeRequestItemRepository;
+    @Mock private WorkChangeRequestRepository workChangeRequestRepository;
+    @Mock private WorkUnavailableTimeRepository workUnavailableTimeRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private WorkplaceRepository workplaceRepository;
+    @Mock private ScheduleValidator scheduleValidator;
+    @Mock private WorkScheduleSettingService workScheduleSettingService;
+    @Mock private SimpMessagingTemplate messagingTemplate;
 
     private ScheduleService scheduleService;
-    private WorkScheduleSlotCommand slot;
+
+    // 09:00~11:00 (2시간 = 30분 단위 4개 슬롯)
+    private final WorkScheduleSlotCommand slot = new WorkScheduleSlotCommand(
+            LocalDate.of(2026, 8, 10),
+            LocalTime.of(9, 0),
+            LocalTime.of(11, 0)
+    );
 
     @BeforeEach
     void setUp() {
         scheduleService = new ScheduleService(
-                workSchedulesRepository,
-                workAttendanceRepository,
-                workChangeRequestItemRepository,
-                workChangeRequestRepository,
-                workUnavailableTimeRepository,
-                userRepository,
-                workplaceRepository,
-                scheduleValidator,
-                workScheduleSettingService,
-                messagingTemplate
-        );
-        slot = new WorkScheduleSlotCommand(
-                LocalDate.of(2026, 8, 10),
-                LocalTime.of(9, 0),
-                LocalTime.of(11, 0)
+                workSchedulesRepository, workAttendanceRepository,
+                workChangeRequestItemRepository, workChangeRequestRepository,
+                workUnavailableTimeRepository, userRepository, workplaceRepository,
+                scheduleValidator, workScheduleSettingService, messagingTemplate
         );
     }
 
     @Test
-    @DisplayName("근무 신청 - 유효한 슬롯을 신청하면 성공 목록에 포함된다")
-    void changeWorkSchedules_AddSlot_Success() {
+    @DisplayName("근무 신청 - 09:00~11:00 신청 시 30분 단위 4개 슬롯이 saveAll로 저장된다")
+    void changeWorkSchedules_AddSlot_SplitsIntoUnitSlotsAndSavesAll() {
         User user = User.builder().userId(1L).organizationId(10L).build();
         WorkScheduleSetting setting = setting();
 
         when(userRepository.findByUserId(1L)).thenReturn(Optional.of(user));
-        when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(any(), any(), any(), any()))
-                .thenReturn(List.of());
-        when(workSchedulesRepository.existsByUser_UserIdAndDateAndStartTimeAndEndTimeAndStatusCodeNot(
-                1L, slot.date(), slot.start(), slot.end(), com.better.CommuteMate.global.code.CodeType.WS04))
-                .thenReturn(false);
-        when(workScheduleSettingService.getRequiredSetting("10", 2026, 8)).thenReturn(setting);
-        when(scheduleValidator.isScheduleInsertable(slot, setting)).thenReturn(true);
-        when(workplaceRepository.findFirstByOrganizationId("10"))
-                .thenReturn(Optional.of(Workplace.builder().organizationId("10").name("본사").build()));
+        // 사용자 기존 슬롯 없음 (중복 없음)
+        when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(
+                any(), any(), any(), any())).thenReturn(List.of());
+        // 해당 날짜 전체 근무 없음 (정원 여유)
+        when(workSchedulesRepository.findAllByDate(any())).thenReturn(List.of());
+        when(workScheduleSettingService.getRequiredSetting(eq(10L), eq(2026), eq(8)))
+                .thenReturn(setting);
+        // 정원 검증 통과 (4개 단위 슬롯 각각 호출)
+        when(scheduleValidator.isScheduleInsertable(
+                any(WorkScheduleSlotCommand.class), anyInt(), anyList())).thenReturn(true);
+        when(workplaceRepository.findFirstByOrganizationId(10L))
+                .thenReturn(Optional.of(Workplace.builder().organizationId(10L).name("본사").build()));
 
         WorkScheduleChangeResultCommand result = scheduleService.changeWorkSchedules(
                 new WorkScheduleChangeCommand(1L, List.of(slot), List.of())
         );
 
+        // 응답은 원본 범위(09:00~11:00) 기준 1건 성공
         assertThat(result.success()).hasSize(1);
         assertThat(result.failure()).isEmpty();
-        verify(workSchedulesRepository).save(any(WorkSchedule.class));
+        // 저장은 saveAll 배치로 처리
+        verify(workSchedulesRepository).saveAll(anyList());
     }
 
     @Test
-    @DisplayName("근무 신청 - 동시 근무 제한을 초과한 슬롯은 실패 목록에 포함된다")
-    void changeWorkSchedules_ConcurrentLimitExceeded_Failure() {
+    @DisplayName("근무 신청 - 단위 슬롯 중 하나라도 정원 초과면 원본 범위 전체가 실패한다")
+    void changeWorkSchedules_ConcurrentLimitExceeded_WholeRangeFails() {
         User user = User.builder().userId(1L).organizationId(10L).build();
         WorkScheduleSetting setting = setting();
 
         when(userRepository.findByUserId(1L)).thenReturn(Optional.of(user));
-        when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(any(), any(), any(), any()))
-                .thenReturn(List.of());
-        when(workScheduleSettingService.getRequiredSetting("10", 2026, 8)).thenReturn(setting);
-        when(scheduleValidator.isScheduleInsertable(slot, setting)).thenReturn(false);
+        when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(
+                any(), any(), any(), any())).thenReturn(List.of());
+        when(workSchedulesRepository.findAllByDate(any())).thenReturn(List.of());
+        when(workScheduleSettingService.getRequiredSetting(eq(10L), eq(2026), eq(8)))
+                .thenReturn(setting);
+        // 정원 초과 (Mock 기본값 false 반환)
 
         WorkScheduleChangeResultCommand result = scheduleService.changeWorkSchedules(
                 new WorkScheduleChangeCommand(1L, List.of(slot), List.of())
@@ -127,24 +124,66 @@ class ScheduleServiceTest {
 
         assertThat(result.success()).isEmpty();
         assertThat(result.failure()).hasSize(1);
-        verify(workSchedulesRepository, never()).save(any());
+        verify(workSchedulesRepository, never()).saveAll(anyList());
     }
 
     @Test
-    @DisplayName("근무 신청 - 추가와 삭제 슬롯이 모두 비어 있으면 실패한다")
+    @DisplayName("근무 신청 - 추가와 삭제 슬롯이 모두 비어 있으면 예외가 발생한다")
     void changeWorkSchedules_EmptyRequest_ThrowsException() {
-        WorkScheduleChangeCommand command = new WorkScheduleChangeCommand(1L, List.of(), List.of());
+        assertThatThrownBy(() -> scheduleService.changeWorkSchedules(
+                new WorkScheduleChangeCommand(1L, List.of(), List.of())))
+                .isInstanceOf(CustomException.class);
+    }
 
-        assertThatThrownBy(() -> scheduleService.changeWorkSchedules(command))
-                .isInstanceOf(com.better.CommuteMate.global.exceptions.CustomException.class);
+    @Test
+    @DisplayName("근무 신청 - 시작 시각이 슬롯 경계가 아니면 400 예외가 발생한다")
+    void changeWorkSchedules_NonBoundaryStart_ThrowsInvalidSlotUnit() {
+        User user = User.builder().userId(1L).organizationId(10L).build();
+        WorkScheduleSetting setting = setting();
+
+        when(userRepository.findByUserId(1L)).thenReturn(Optional.of(user));
+        when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(
+                any(), any(), any(), any())).thenReturn(List.of());
+        when(workScheduleSettingService.getRequiredSetting(eq(10L), eq(2026), eq(8)))
+                .thenReturn(setting);
+
+        // 09:15~09:45 : 시작이 슬롯 경계 아님 (30분 단위인데 15분 시작)
+        WorkScheduleSlotCommand badSlot = new WorkScheduleSlotCommand(
+                LocalDate.of(2026, 8, 10), LocalTime.of(9, 15), LocalTime.of(9, 45));
+
+        assertThatThrownBy(() -> scheduleService.changeWorkSchedules(
+                new WorkScheduleChangeCommand(1L, List.of(badSlot), List.of())))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("근무 신청 - 길이가 최소 단위 배수가 아니면 400 예외가 발생한다")
+    void changeWorkSchedules_NonMultipleDuration_ThrowsInvalidSlotUnit() {
+        User user = User.builder().userId(1L).organizationId(10L).build();
+        WorkScheduleSetting setting = setting();
+
+        when(userRepository.findByUserId(1L)).thenReturn(Optional.of(user));
+        when(workSchedulesRepository.findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(
+                any(), any(), any(), any())).thenReturn(List.of());
+        when(workScheduleSettingService.getRequiredSetting(eq(10L), eq(2026), eq(8)))
+                .thenReturn(setting);
+
+        // 09:00~09:45 : 45분은 30의 배수 아님
+        WorkScheduleSlotCommand badSlot = new WorkScheduleSlotCommand(
+                LocalDate.of(2026, 8, 10), LocalTime.of(9, 0), LocalTime.of(9, 45));
+
+        assertThatThrownBy(() -> scheduleService.changeWorkSchedules(
+                new WorkScheduleChangeCommand(1L, List.of(badSlot), List.of())))
+                .isInstanceOf(CustomException.class);
     }
 
     private WorkScheduleSetting setting() {
         return WorkScheduleSetting.builder()
-                .organizationId("10")
+                .organizationId(10L)
                 .year(2026)
                 .month(8)
                 .maxConcurrentWorkers(3)
+                .minWorkUnitMinutes(30)
                 .monthlyRequiredMinutes(27 * 60)
                 .weeklyMaxMinutes(13 * 60)
                 .applyStartAt(LocalDateTime.of(2020, 1, 1, 0, 0))


### PR DESCRIPTION
## 1. 요약 📝

- 근무 일정을 최소 근무 단위 슬롯으로 분할 저장하도록 구조를 변경, 이를 기반으로 홈 화면의 오늘 근무 조회·출근 API를 구현

- 기존에는 사용자가 신청한 시간 범위를 그대로 한 행으로 저장해, 같은 09:00~11:00 근무라도 신청 방식(한 번에 신청 vs 나눠서 신청)에 따라 데이터 구조가 달라지는 문제가 있었음. 입력 형태와 무관하게 항상 슬롯 단위로 저장하고, 조회 시 연속된 슬롯을 병합해 하나의 근무로 응답하는 방식으로 변경

## 2. 관련 이슈 🔗


## 3. 주요 변경 사항 🔑

**근무 일정 슬롯 단위 저장**
- 근무 신청 시 `work_schedule_setting.min_work_unit_minutes` 기준으로 슬롯을 자동 분할해 `work_schedule`에 각각 저장
- `WorkSlotUtils` 신규 추출 — 슬롯 분할 공통 로직
- 변경된 저장 방식에 맞춰 `AdminWorkChangeRequestProcessService`, `ScheduleValidator` 수정
- `ScheduleServiceTest` 전체 케이스를 새 슬롯 구조에 맞게 업데이트

**오늘의 근무 일정 조회 — `GET /api/v1/home/today`**
- 연속 슬롯(`prev.endTime == next.startTime`)을 하나의 근무 카드로 병합해 응답
- 응답 구조: `scheduleIds`(병합에 포함된 슬롯 ID 배열), `label`(시작 시각 기준 오전/오후), `start`, `end`, `workStatusCode`, `checkedIn`, `checkInTime`
- `workStatusCode`는 DB 저장값이 아니라 출근 기록과 현재 시각으로 실시간 계산 — WK01(예정) / WK02(근무중) / WK03(근무완료) / WK04(결근)

**출근 처리 — `POST /api/v1/home/check-in`**
- 조회 API가 내려준 `scheduleIds` 배열을 그대로 전달하면 포함된 슬롯 전체에 출근 기록을 원자적으로 저장
- 연속성 검증, 중복 출근 차단, 근무 시작 + 10분 초과 시 출근 거부
- `AttendanceErrorCode`에 `SCHEDULE_NOT_FOUND`, `NOT_CONSECUTIVE_SLOTS`, `CHECK_IN_LATE` 추가

* `ScheduleSlotUtils` 신규 추가 — `mergeConsecutiveSlots()` / `isConsecutive()`를 조회·출근 API에서 공통 재사용

**인증 누락 수정**
- `SecurityConfig`에서 일부 엔드포인트가 인증 없이 접근 가능하던 문제 수정 — 누락된 경로에 인증 규칙 추가
- `WorkScheduleController` 관련 어노테이션 보완

## 4. 기타 💬