### PR TITLE
[FEAT] 관리자 업무사항 api 구현

### DIFF
--- a/src/main/java/com/better/CommuteMate/domain/handovermemo/entity/HandoverMemo.java
+++ b/src/main/java/com/better/CommuteMate/domain/handovermemo/entity/HandoverMemo.java
@@ -1,0 +1,57 @@
+package com.better.CommuteMate.domain.handovermemo.entity;
+
+import com.better.CommuteMate.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "handover_memo", indexes = {
+        @Index(name = "idx_handover_memo_org_created", columnList = "organization_id, created_at")
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class HandoverMemo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memo_id", nullable = false)
+    private Long memoId;
+
+    @Column(name = "organization_id", nullable = false)
+    private Long organizationId;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/better/CommuteMate/domain/handovermemo/repository/HandoverMemoRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/handovermemo/repository/HandoverMemoRepository.java
@@ -1,0 +1,29 @@
+package com.better.CommuteMate.domain.handovermemo.repository;
+
+import com.better.CommuteMate.domain.handovermemo.entity.HandoverMemo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface HandoverMemoRepository extends JpaRepository<HandoverMemo, Long> {
+
+    @Query("""
+            select memo
+            from HandoverMemo memo
+            join fetch memo.createdBy
+            where memo.organizationId = :organizationId
+              and memo.createdAt >= :startAt
+              and memo.createdAt < :endAt
+            order by memo.createdAt asc, memo.memoId asc
+            """)
+    List<HandoverMemo> findDailyMemos(
+            @Param("organizationId") Long organizationId,
+            @Param("startAt") LocalDateTime startAt,
+            @Param("endAt") LocalDateTime endAt
+    );
+}

--- a/src/main/java/com/better/CommuteMate/domain/task/entity/Task.java
+++ b/src/main/java/com/better/CommuteMate/domain/task/entity/Task.java
@@ -89,6 +89,24 @@ public class Task {
         this.updatedBy = updatedBy;
     }
 
+    public void updateAdminTodo(
+            LocalDate taskDate,
+            LocalTime taskTime,
+            String title,
+            Long updatedBy
+    ) {
+        if (taskDate != null) {
+            this.taskDate = taskDate;
+        }
+        if (taskTime != null) {
+            this.taskTime = taskTime;
+        }
+        if (title != null) {
+            this.title = title;
+        }
+        this.updatedBy = updatedBy;
+    }
+
     // 완료 상태 토글
     public void toggleComplete(Long updatedBy) {
         this.isCompleted = !this.isCompleted;

--- a/src/main/java/com/better/CommuteMate/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/better/CommuteMate/domain/task/repository/TaskRepository.java
@@ -15,6 +15,22 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     List<Task> findAllByAssignee_OrganizationIdAndTaskDate(Long organizationId, LocalDate taskDate);
 
+    @Query("""
+            select task
+            from Task task
+            where task.taskDate = :taskDate
+              and task.createdBy in (
+                select creator.userId
+                from User creator
+                where creator.organizationId = :organizationId
+              )
+            order by task.taskTime asc, task.taskId asc
+            """)
+    List<Task> findAdminTodos(
+            @Param("organizationId") Long organizationId,
+            @Param("taskDate") LocalDate taskDate
+    );
+
     /**
      * 특정 날짜의 모든 업무 조회 (시간순 정렬)
      */

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/HandoverMemoErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/HandoverMemoErrorCode.java
@@ -1,0 +1,41 @@
+package com.better.CommuteMate.global.exceptions.error;
+
+import org.springframework.http.HttpStatus;
+
+public enum HandoverMemoErrorCode implements CustomErrorCode {
+    INVALID_DATE_FORMAT(
+            "날짜 형식이 올바르지 않습니다.",
+            "[Error] : invalid handover memo date format",
+            HttpStatus.BAD_REQUEST
+    );
+
+    private final String message;
+    private final String logMessage;
+    private final HttpStatus status;
+
+    HandoverMemoErrorCode(String message, String logMessage, HttpStatus status) {
+        this.message = message;
+        this.logMessage = logMessage;
+        this.status = status;
+    }
+
+    @Override
+    public String getLogMessage() {
+        return logMessage;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/TaskErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/TaskErrorCode.java
@@ -33,6 +33,10 @@ public enum TaskErrorCode implements CustomErrorCode {
             "업무사항을 수정할 권한이 없습니다.",
             "[Error] : admin todo update access denied",
             HttpStatus.FORBIDDEN),
+    TODO_DELETE_ACCESS_DENIED(
+            "업무사항을 삭제할 권한이 없습니다.",
+            "[Error] : admin todo delete access denied",
+            HttpStatus.FORBIDDEN),
     TODO_NOT_FOUND(
             "업무사항을 찾을 수 없습니다.",
             "[Error] : admin todo not found",

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/TaskErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/TaskErrorCode.java
@@ -29,6 +29,14 @@ public enum TaskErrorCode implements CustomErrorCode {
             "업무사항 입력값이 올바르지 않습니다.",
             "[Error] : invalid admin todo information",
             HttpStatus.BAD_REQUEST),
+    TODO_UPDATE_ACCESS_DENIED(
+            "업무사항을 수정할 권한이 없습니다.",
+            "[Error] : admin todo update access denied",
+            HttpStatus.FORBIDDEN),
+    TODO_NOT_FOUND(
+            "업무사항을 찾을 수 없습니다.",
+            "[Error] : admin todo not found",
+            HttpStatus.NOT_FOUND),
     INVALID_TASK_TYPE(
             "업무 유형이 유효하지 않습니다. TT01(정기) 또는 TT02(비정기)를 사용해주세요.",
             "[Error] : 업무 유형 유효성 검증 실패",

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/TaskErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/TaskErrorCode.java
@@ -21,6 +21,10 @@ public enum TaskErrorCode implements CustomErrorCode {
             "업무 날짜가 유효하지 않습니다.",
             "[Error] : 업무 날짜 유효성 검증 실패",
             HttpStatus.BAD_REQUEST),
+    INVALID_TODO_DATE(
+            "날짜 형식이 올바르지 않습니다.",
+            "[Error] : invalid admin todo date format",
+            HttpStatus.BAD_REQUEST),
     INVALID_TASK_TYPE(
             "업무 유형이 유효하지 않습니다. TT01(정기) 또는 TT02(비정기)를 사용해주세요.",
             "[Error] : 업무 유형 유효성 검증 실패",

--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/TaskErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/TaskErrorCode.java
@@ -25,6 +25,10 @@ public enum TaskErrorCode implements CustomErrorCode {
             "날짜 형식이 올바르지 않습니다.",
             "[Error] : invalid admin todo date format",
             HttpStatus.BAD_REQUEST),
+    INVALID_TODO_INFORMATION(
+            "업무사항 입력값이 올바르지 않습니다.",
+            "[Error] : invalid admin todo information",
+            HttpStatus.BAD_REQUEST),
     INVALID_TASK_TYPE(
             "업무 유형이 유효하지 않습니다. TT01(정기) 또는 TT02(비정기)를 사용해주세요.",
             "[Error] : 업무 유형 유효성 검증 실패",

--- a/src/main/java/com/better/CommuteMate/home/application/AdminHomeService.java
+++ b/src/main/java/com/better/CommuteMate/home/application/AdminHomeService.java
@@ -119,6 +119,6 @@ public class AdminHomeService {
         return attendances.stream()
                 .filter(attendance -> attendance.getCheckTypeCode() == CodeType.CT01)
                 .map(WorkAttendance::getCheckTime)
-                .anyMatch(checkIn -> checkIn.isAfter(scheduledStart));
+                .anyMatch(checkIn -> checkIn.isAfter(scheduledStart.plusMinutes(10)));
     }
 }

--- a/src/main/java/com/better/CommuteMate/task/application/AdminTodoService.java
+++ b/src/main/java/com/better/CommuteMate/task/application/AdminTodoService.java
@@ -9,6 +9,8 @@ import com.better.CommuteMate.global.exceptions.error.TaskErrorCode;
 import com.better.CommuteMate.task.controller.dtos.AdminTodosResponse;
 import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoRequest;
 import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoResponse;
+import com.better.CommuteMate.task.controller.dtos.UpdateAdminTodoRequest;
+import com.better.CommuteMate.task.controller.dtos.UpdateAdminTodoResponse;
 import com.better.CommuteMate.global.code.CodeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,6 +59,30 @@ public class AdminTodoService {
         return CreateAdminTodoResponse.from(taskRepository.save(task));
     }
 
+    @Transactional
+    public UpdateAdminTodoResponse updateTodo(
+            Long todoId,
+            UpdateAdminTodoRequest request,
+            Long adminId
+    ) {
+        Task task = taskRepository.findById(todoId)
+                .orElseThrow(() -> CustomException.of(TaskErrorCode.TODO_NOT_FOUND));
+        validateUpdateAccess(task, adminId);
+
+        if (request.date() == null
+                && request.timeSlot() == null
+                && request.description() == null) {
+            throw CustomException.of(TaskErrorCode.INVALID_TODO_INFORMATION);
+        }
+
+        LocalDate date = parseOptionalDate(request.date());
+        LocalTime timeSlot = parseOptionalTime(request.timeSlot());
+        String description = parseOptionalDescription(request.description());
+
+        task.updateAdminTodo(date, timeSlot, description, adminId);
+        return UpdateAdminTodoResponse.from(taskRepository.saveAndFlush(task));
+    }
+
     public AdminTodosResponse getTodos(Long organizationId, String dateValue) {
         LocalDate date = parseDate(dateValue);
         List<Task> tasks = taskRepository.findAdminTodos(organizationId, date);
@@ -82,6 +108,52 @@ public class AdminTodoService {
             return LocalDate.parse(value);
         } catch (DateTimeParseException e) {
             throw CustomException.of(TaskErrorCode.INVALID_TODO_DATE);
+        }
+    }
+
+    private LocalDate parseOptionalDate(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw CustomException.of(TaskErrorCode.INVALID_TODO_INFORMATION);
+        }
+    }
+
+    private LocalTime parseOptionalTime(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return LocalTime.parse(value);
+        } catch (DateTimeParseException e) {
+            throw CustomException.of(TaskErrorCode.INVALID_TODO_INFORMATION);
+        }
+    }
+
+    private String parseOptionalDescription(String value) {
+        if (value == null) {
+            return null;
+        }
+        String description = value.trim();
+        if (description.isEmpty()) {
+            throw CustomException.of(TaskErrorCode.INVALID_TODO_INFORMATION);
+        }
+        return description;
+    }
+
+    private void validateUpdateAccess(Task task, Long adminId) {
+        User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> CustomException.of(TaskErrorCode.TODO_UPDATE_ACCESS_DENIED));
+        User creator = task.getCreatedBy() == null
+                ? null
+                : userRepository.findById(task.getCreatedBy()).orElse(null);
+
+        if (creator == null
+                || !Objects.equals(admin.getOrganizationId(), creator.getOrganizationId())) {
+            throw CustomException.of(TaskErrorCode.TODO_UPDATE_ACCESS_DENIED);
         }
     }
 

--- a/src/main/java/com/better/CommuteMate/task/application/AdminTodoService.java
+++ b/src/main/java/com/better/CommuteMate/task/application/AdminTodoService.java
@@ -7,6 +7,9 @@ import com.better.CommuteMate.domain.user.repository.UserRepository;
 import com.better.CommuteMate.global.exceptions.CustomException;
 import com.better.CommuteMate.global.exceptions.error.TaskErrorCode;
 import com.better.CommuteMate.task.controller.dtos.AdminTodosResponse;
+import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoRequest;
+import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoResponse;
+import com.better.CommuteMate.global.code.CodeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +32,30 @@ public class AdminTodoService {
 
     private final TaskRepository taskRepository;
     private final UserRepository userRepository;
+
+    @Transactional
+    public CreateAdminTodoResponse createTodo(
+            CreateAdminTodoRequest request,
+            Long adminId
+    ) {
+        LocalDate date;
+        LocalTime timeSlot;
+        try {
+            date = LocalDate.parse(request.date());
+            timeSlot = LocalTime.parse(request.timeSlot());
+        } catch (DateTimeParseException e) {
+            throw CustomException.of(TaskErrorCode.INVALID_TODO_INFORMATION);
+        }
+
+        Task task = Task.create(
+                request.description().trim(),
+                date,
+                timeSlot,
+                CodeType.TT01,
+                adminId
+        );
+        return CreateAdminTodoResponse.from(taskRepository.save(task));
+    }
 
     public AdminTodosResponse getTodos(Long organizationId, String dateValue) {
         LocalDate date = parseDate(dateValue);

--- a/src/main/java/com/better/CommuteMate/task/application/AdminTodoService.java
+++ b/src/main/java/com/better/CommuteMate/task/application/AdminTodoService.java
@@ -1,0 +1,73 @@
+package com.better.CommuteMate.task.application;
+
+import com.better.CommuteMate.domain.task.entity.Task;
+import com.better.CommuteMate.domain.task.repository.TaskRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.TaskErrorCode;
+import com.better.CommuteMate.task.controller.dtos.AdminTodosResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminTodoService {
+
+    private static final LocalTime NOON = LocalTime.NOON;
+
+    private final TaskRepository taskRepository;
+    private final UserRepository userRepository;
+
+    public AdminTodosResponse getTodos(Long organizationId, String dateValue) {
+        LocalDate date = parseDate(dateValue);
+        List<Task> tasks = taskRepository.findAdminTodos(organizationId, date);
+        Map<Long, User> creators = findCreators(tasks);
+
+        List<AdminTodosResponse.TodoItem> morningTodos = tasks.stream()
+                .filter(task -> task.getTaskTime().isBefore(NOON))
+                .map(task -> AdminTodosResponse.toItem(task, creators))
+                .toList();
+        List<AdminTodosResponse.TodoItem> afternoonTodos = tasks.stream()
+                .filter(task -> !task.getTaskTime().isBefore(NOON))
+                .map(task -> AdminTodosResponse.toItem(task, creators))
+                .toList();
+
+        return new AdminTodosResponse(date, morningTodos, afternoonTodos);
+    }
+
+    private LocalDate parseDate(String value) {
+        if (value == null || value.isBlank()) {
+            throw CustomException.of(TaskErrorCode.INVALID_TODO_DATE);
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw CustomException.of(TaskErrorCode.INVALID_TODO_DATE);
+        }
+    }
+
+    private Map<Long, User> findCreators(List<Task> tasks) {
+        List<Long> creatorIds = tasks.stream()
+                .map(Task::getCreatedBy)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (creatorIds.isEmpty()) {
+            return Map.of();
+        }
+        return userRepository.findAllById(creatorIds).stream()
+                .collect(Collectors.toMap(User::getUserId, Function.identity()));
+    }
+}

--- a/src/main/java/com/better/CommuteMate/task/application/AdminTodoService.java
+++ b/src/main/java/com/better/CommuteMate/task/application/AdminTodoService.java
@@ -83,6 +83,14 @@ public class AdminTodoService {
         return UpdateAdminTodoResponse.from(taskRepository.saveAndFlush(task));
     }
 
+    @Transactional
+    public void deleteTodo(Long todoId, Long adminId) {
+        Task task = taskRepository.findById(todoId)
+                .orElseThrow(() -> CustomException.of(TaskErrorCode.TODO_NOT_FOUND));
+        validateDeleteAccess(task, adminId);
+        taskRepository.delete(task);
+    }
+
     public AdminTodosResponse getTodos(Long organizationId, String dateValue) {
         LocalDate date = parseDate(dateValue);
         List<Task> tasks = taskRepository.findAdminTodos(organizationId, date);
@@ -145,16 +153,26 @@ public class AdminTodoService {
     }
 
     private void validateUpdateAccess(Task task, Long adminId) {
+        if (!hasSameOrganization(task, adminId)) {
+            throw CustomException.of(TaskErrorCode.TODO_UPDATE_ACCESS_DENIED);
+        }
+    }
+
+    private void validateDeleteAccess(Task task, Long adminId) {
+        if (!hasSameOrganization(task, adminId)) {
+            throw CustomException.of(TaskErrorCode.TODO_DELETE_ACCESS_DENIED);
+        }
+    }
+
+    private boolean hasSameOrganization(Task task, Long adminId) {
         User admin = userRepository.findById(adminId)
-                .orElseThrow(() -> CustomException.of(TaskErrorCode.TODO_UPDATE_ACCESS_DENIED));
+                .orElse(null);
         User creator = task.getCreatedBy() == null
                 ? null
                 : userRepository.findById(task.getCreatedBy()).orElse(null);
-
-        if (creator == null
-                || !Objects.equals(admin.getOrganizationId(), creator.getOrganizationId())) {
-            throw CustomException.of(TaskErrorCode.TODO_UPDATE_ACCESS_DENIED);
-        }
+        return admin != null
+                && creator != null
+                && Objects.equals(admin.getOrganizationId(), creator.getOrganizationId());
     }
 
     private Map<Long, User> findCreators(List<Task> tasks) {

--- a/src/main/java/com/better/CommuteMate/task/application/HandoverMemoService.java
+++ b/src/main/java/com/better/CommuteMate/task/application/HandoverMemoService.java
@@ -1,0 +1,46 @@
+package com.better.CommuteMate.task.application;
+
+import com.better.CommuteMate.domain.handovermemo.entity.HandoverMemo;
+import com.better.CommuteMate.domain.handovermemo.repository.HandoverMemoRepository;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.global.exceptions.error.HandoverMemoErrorCode;
+import com.better.CommuteMate.task.controller.dtos.HandoverMemosResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HandoverMemoService {
+
+    private final HandoverMemoRepository handoverMemoRepository;
+
+    public HandoverMemosResponse getMemos(Long organizationId, String dateValue) {
+        LocalDate date = parseDate(dateValue);
+        List<HandoverMemo> memos = handoverMemoRepository.findDailyMemos(
+                organizationId,
+                date.atStartOfDay(),
+                date.plusDays(1).atStartOfDay()
+        );
+        return new HandoverMemosResponse(
+                date,
+                memos.stream().map(HandoverMemosResponse::toItem).toList()
+        );
+    }
+
+    private LocalDate parseDate(String value) {
+        if (value == null || value.isBlank()) {
+            throw CustomException.of(HandoverMemoErrorCode.INVALID_DATE_FORMAT);
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw CustomException.of(HandoverMemoErrorCode.INVALID_DATE_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/better/CommuteMate/task/controller/AdminTodoController.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/AdminTodoController.java
@@ -23,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -189,6 +190,71 @@ public class AdminTodoController {
                 "업무사항 수정에 성공했습니다.",
                 details
         ));
+    }
+
+    @DeleteMapping("/{todoId}")
+    @PreAuthorize("hasRole('RL02')")
+    @Operation(
+            summary = "관리자 업무사항 삭제",
+            description = "업무사항을 삭제합니다. 같은 조직의 관리자만 삭제할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "업무사항 삭제 성공",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "인증이 필요합니다.",
+                                      "details": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "업무사항 삭제 권한 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "업무사항을 삭제할 권한이 없습니다.",
+                                      "details": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "업무사항을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "업무사항을 찾을 수 없습니다.",
+                                      "details": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Void> deleteTodo(
+            @Parameter(description = "삭제할 업무사항 ID", example = "1", required = true)
+            @PathVariable Long todoId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        adminTodoService.deleteTodo(todoId, userDetails.getUserId());
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping

--- a/src/main/java/com/better/CommuteMate/task/controller/AdminTodoController.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/AdminTodoController.java
@@ -6,6 +6,8 @@ import com.better.CommuteMate.task.application.AdminTodoService;
 import com.better.CommuteMate.task.controller.dtos.AdminTodosResponse;
 import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoRequest;
 import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoResponse;
+import com.better.CommuteMate.task.controller.dtos.UpdateAdminTodoRequest;
+import com.better.CommuteMate.task.controller.dtos.UpdateAdminTodoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -21,6 +23,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin/todos")
 @RequiredArgsConstructor
-@Tag(name = "Admin Todo", description = "관리자 업무사항 조회 API")
+@Tag(name = "Admin Todo", description = "관리자 업무사항 API")
 public class AdminTodoController {
 
     private final AdminTodoService adminTodoService;
@@ -92,6 +96,97 @@ public class AdminTodoController {
         return ResponseEntity.status(HttpStatus.CREATED).body(Response.of(
                 true,
                 "업무사항 등록에 성공했습니다.",
+                details
+        ));
+    }
+
+    @PatchMapping("/{todoId}")
+    @PreAuthorize("hasRole('RL02')")
+    @Operation(
+            summary = "관리자 업무사항 수정",
+            description = "업무 날짜, 시간, 내용 중 전달된 필드만 수정합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "date": "2026-04-15",
+                                      "timeSlot": "14:00",
+                                      "description": "회의실 청소"
+                                    }
+                                    """)
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "업무사항 수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = UPDATE_SUCCESS_EXAMPLE)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "업무사항 입력값 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "업무사항 입력값이 올바르지 않습니다.",
+                                      "details": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "업무사항 수정 권한 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "업무사항을 수정할 권한이 없습니다.",
+                                      "details": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "업무사항을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "업무사항을 찾을 수 없습니다.",
+                                      "details": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> updateTodo(
+            @Parameter(description = "수정할 업무사항 ID", example = "1", required = true)
+            @PathVariable Long todoId,
+            @Valid @RequestBody UpdateAdminTodoRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        UpdateAdminTodoResponse details = adminTodoService.updateTodo(
+                todoId,
+                request,
+                userDetails.getUserId()
+        );
+        return ResponseEntity.ok(Response.of(
+                true,
+                "업무사항 수정에 성공했습니다.",
                 details
         ));
     }
@@ -223,6 +318,22 @@ public class AdminTodoController {
                 "status": "PENDING",
                 "completed": false,
                 "createdAt": "2026-04-15T08:30:00"
+              }
+            }
+            """;
+
+    private static final String UPDATE_SUCCESS_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "업무사항 수정에 성공했습니다.",
+              "details": {
+                "todoId": 1,
+                "date": "2026-04-15",
+                "timeSlot": "14:00:00",
+                "description": "회의실 청소",
+                "status": "PENDING",
+                "completed": false,
+                "updatedAt": "2026-04-15T10:40:00"
               }
             }
             """;

--- a/src/main/java/com/better/CommuteMate/task/controller/AdminTodoController.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/AdminTodoController.java
@@ -4,6 +4,8 @@ import com.better.CommuteMate.auth.application.CustomUserDetails;
 import com.better.CommuteMate.global.controller.dtos.Response;
 import com.better.CommuteMate.task.application.AdminTodoService;
 import com.better.CommuteMate.task.controller.dtos.AdminTodosResponse;
+import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoRequest;
+import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,10 +15,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +34,67 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminTodoController {
 
     private final AdminTodoService adminTodoService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('RL02')")
+    @Operation(
+            summary = "관리자 업무사항 등록",
+            description = "특정 날짜와 시간에 수행할 업무사항을 등록합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "date": "2026-04-15",
+                                      "timeSlot": "09:00",
+                                      "description": "신문지 가져오기"
+                                    }
+                                    """)
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "업무사항 등록 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = CREATE_SUCCESS_EXAMPLE)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "업무사항 입력값 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "업무사항 입력값이 올바르지 않습니다.",
+                                      "details": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> createTodo(
+            @Valid @RequestBody CreateAdminTodoRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        CreateAdminTodoResponse details = adminTodoService.createTodo(
+                request,
+                userDetails.getUserId()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(Response.of(
+                true,
+                "업무사항 등록에 성공했습니다.",
+                details
+        ));
+    }
 
     @GetMapping
     @PreAuthorize("hasRole('RL02')")
@@ -140,6 +207,22 @@ public class AdminTodoController {
                 "date": "2026-04-15",
                 "morningTodos": [],
                 "afternoonTodos": []
+              }
+            }
+            """;
+
+    private static final String CREATE_SUCCESS_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "업무사항 등록에 성공했습니다.",
+              "details": {
+                "todoId": 1,
+                "date": "2026-04-15",
+                "timeSlot": "09:00:00",
+                "description": "신문지 가져오기",
+                "status": "PENDING",
+                "completed": false,
+                "createdAt": "2026-04-15T08:30:00"
               }
             }
             """;

--- a/src/main/java/com/better/CommuteMate/task/controller/AdminTodoController.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/AdminTodoController.java
@@ -1,0 +1,146 @@
+package com.better.CommuteMate.task.controller;
+
+import com.better.CommuteMate.auth.application.CustomUserDetails;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.task.application.AdminTodoService;
+import com.better.CommuteMate.task.controller.dtos.AdminTodosResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/todos")
+@RequiredArgsConstructor
+@Tag(name = "Admin Todo", description = "관리자 업무사항 조회 API")
+public class AdminTodoController {
+
+    private final AdminTodoService adminTodoService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('RL02')")
+    @Operation(summary = "관리자 일별 업무사항 조회", description = "특정 날짜의 업무사항을 오전과 오후로 구분하여 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "업무사항 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "조회 결과 있음",
+                                            value = SUCCESS_EXAMPLE
+                                    ),
+                                    @ExampleObject(
+                                            name = "업무사항 없음",
+                                            value = EMPTY_EXAMPLE
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "날짜 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "날짜 형식이 올바르지 않습니다.",
+                                      "details": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getTodos(
+            @Parameter(description = "조회할 업무 날짜 (yyyy-MM-dd)", example = "2026-04-15", required = true)
+            @RequestParam String date,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        AdminTodosResponse details = adminTodoService.getTodos(
+                userDetails.getUser().getOrganizationId(), date
+        );
+        return ResponseEntity.ok(Response.of(true, "업무사항 조회에 성공했습니다.", details));
+    }
+
+    private static final String SUCCESS_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "업무사항 조회에 성공했습니다.",
+              "details": {
+                "date": "2026-04-15",
+                "morningTodos": [
+                  {
+                    "todoId": 1,
+                    "description": "신문지 가져오기",
+                    "timeSlot": "09:00:00",
+                    "status": "COMPLETED",
+                    "createdBy": {
+                      "userId": 7,
+                      "name": "홍길동"
+                    },
+                    "createdAt": "2026-04-15T08:50:00",
+                    "completedByName": "홍길동",
+                    "completedTime": "09:13:00"
+                  },
+                  {
+                    "todoId": 2,
+                    "description": "커피머신 청소",
+                    "timeSlot": "10:00:00",
+                    "status": "PENDING",
+                    "createdBy": {
+                      "userId": 7,
+                      "name": "홍길동"
+                    },
+                    "createdAt": "2026-04-15T08:55:00",
+                    "completedByName": null,
+                    "completedTime": null
+                  }
+                ],
+                "afternoonTodos": [
+                  {
+                    "todoId": 3,
+                    "description": "회의실 청소",
+                    "timeSlot": "14:00:00",
+                    "status": "PENDING",
+                    "createdBy": {
+                      "userId": 7,
+                      "name": "홍길동"
+                    },
+                    "createdAt": "2026-04-15T09:00:00",
+                    "completedByName": null,
+                    "completedTime": null
+                  }
+                ]
+              }
+            }
+            """;
+
+    private static final String EMPTY_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "업무사항 조회에 성공했습니다.",
+              "details": {
+                "date": "2026-04-15",
+                "morningTodos": [],
+                "afternoonTodos": []
+              }
+            }
+            """;
+}

--- a/src/main/java/com/better/CommuteMate/task/controller/HandoverMemoController.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/HandoverMemoController.java
@@ -1,0 +1,113 @@
+package com.better.CommuteMate.task.controller;
+
+import com.better.CommuteMate.auth.application.CustomUserDetails;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.task.application.HandoverMemoService;
+import com.better.CommuteMate.task.controller.dtos.HandoverMemosResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/handover-memos")
+@RequiredArgsConstructor
+@Tag(name = "Admin Handover Memo", description = "관리자 인수인계 메모 API")
+public class HandoverMemoController {
+
+    private final HandoverMemoService handoverMemoService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('RL02')")
+    @Operation(summary = "일별 인수인계 메모 조회", description = "관리자 조직의 특정 날짜 인수인계 메모를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "인수인계 메모 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "조회 결과 있음", value = SUCCESS_EXAMPLE),
+                                    @ExampleObject(name = "메모 없음", value = EMPTY_EXAMPLE)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "날짜 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "날짜 형식이 올바르지 않습니다.",
+                                      "details": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getMemos(
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-04-15", required = true)
+            @RequestParam String date,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        HandoverMemosResponse details = handoverMemoService.getMemos(
+                userDetails.getUser().getOrganizationId(), date
+        );
+        return ResponseEntity.ok(Response.of(
+                true,
+                "인수인계 메모 조회에 성공했습니다.",
+                details
+        ));
+    }
+
+    private static final String SUCCESS_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "인수인계 메모 조회에 성공했습니다.",
+              "details": {
+                "date": "2026-04-15",
+                "memoCount": 1,
+                "memos": [
+                  {
+                    "memoId": 1,
+                    "content": "다음 근무자가 쓰레기봉투 꼭 갈아주세요.",
+                    "createdBy": {
+                      "userId": 7,
+                      "name": "홍길동"
+                    },
+                    "createdAt": "2026-04-15T10:36:00"
+                  }
+                ]
+              }
+            }
+            """;
+
+    private static final String EMPTY_EXAMPLE = """
+            {
+              "isSuccess": true,
+              "message": "인수인계 메모 조회에 성공했습니다.",
+              "details": {
+                "date": "2026-04-15",
+                "memoCount": 0,
+                "memos": []
+              }
+            }
+            """;
+}

--- a/src/main/java/com/better/CommuteMate/task/controller/dtos/AdminTodosResponse.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/dtos/AdminTodosResponse.java
@@ -1,0 +1,59 @@
+package com.better.CommuteMate.task.controller.dtos;
+
+import com.better.CommuteMate.domain.task.entity.Task;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+public class AdminTodosResponse extends ResponseDetail {
+    public final LocalDate date;
+    public final List<TodoItem> morningTodos;
+    public final List<TodoItem> afternoonTodos;
+
+    public AdminTodosResponse(LocalDate date, List<TodoItem> morningTodos, List<TodoItem> afternoonTodos) {
+        this.date = date;
+        this.morningTodos = morningTodos;
+        this.afternoonTodos = afternoonTodos;
+    }
+
+    public static TodoItem toItem(Task task, Map<Long, User> creators) {
+        User creator = creators.get(task.getCreatedBy());
+        return new TodoItem(
+                task.getTaskId(),
+                task.getTitle(),
+                task.getTaskTime(),
+                Boolean.TRUE.equals(task.getIsCompleted()) ? "COMPLETED" : "PENDING",
+                creator == null ? null : new CreatedBy(creator.getUserId(), creator.getName()),
+                task.getCreatedAt(),
+                task.getCompletedByName(),
+                task.getCompletedTime()
+        );
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+
+    public record TodoItem(
+            Long todoId,
+            String description,
+            LocalTime timeSlot,
+            String status,
+            CreatedBy createdBy,
+            LocalDateTime createdAt,
+            String completedByName,
+            LocalTime completedTime
+    ) {
+    }
+
+    public record CreatedBy(Long userId, String name) {
+    }
+}

--- a/src/main/java/com/better/CommuteMate/task/controller/dtos/CreateAdminTodoRequest.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/dtos/CreateAdminTodoRequest.java
@@ -1,0 +1,20 @@
+package com.better.CommuteMate.task.controller.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateAdminTodoRequest(
+        @NotBlank(message = "업무사항 입력값이 올바르지 않습니다.")
+        @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "업무사항 입력값이 올바르지 않습니다.")
+        String date,
+
+        @NotBlank(message = "업무사항 입력값이 올바르지 않습니다.")
+        @Pattern(regexp = "(?:[01]\\d|2[0-3]):[0-5]\\d", message = "업무사항 입력값이 올바르지 않습니다.")
+        String timeSlot,
+
+        @NotBlank(message = "업무사항 입력값이 올바르지 않습니다.")
+        @Size(max = 200, message = "업무사항 입력값이 올바르지 않습니다.")
+        String description
+) {
+}

--- a/src/main/java/com/better/CommuteMate/task/controller/dtos/CreateAdminTodoResponse.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/dtos/CreateAdminTodoResponse.java
@@ -1,0 +1,39 @@
+package com.better.CommuteMate.task.controller.dtos;
+
+import com.better.CommuteMate.domain.task.entity.Task;
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class CreateAdminTodoResponse extends ResponseDetail {
+    public final Long todoId;
+    public final LocalDate date;
+    public final LocalTime timeSlot;
+    public final String description;
+    public final String status;
+    public final boolean completed;
+    public final LocalDateTime createdAt;
+
+    private CreateAdminTodoResponse(Task task) {
+        this.todoId = task.getTaskId();
+        this.date = task.getTaskDate();
+        this.timeSlot = task.getTaskTime();
+        this.description = task.getTitle();
+        this.completed = Boolean.TRUE.equals(task.getIsCompleted());
+        this.status = completed ? "COMPLETED" : "PENDING";
+        this.createdAt = task.getCreatedAt();
+    }
+
+    public static CreateAdminTodoResponse from(Task task) {
+        return new CreateAdminTodoResponse(task);
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+}

--- a/src/main/java/com/better/CommuteMate/task/controller/dtos/HandoverMemosResponse.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/dtos/HandoverMemosResponse.java
@@ -1,0 +1,50 @@
+package com.better.CommuteMate.task.controller.dtos;
+
+import com.better.CommuteMate.domain.handovermemo.entity.HandoverMemo;
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class HandoverMemosResponse extends ResponseDetail {
+    public final LocalDate date;
+    public final int memoCount;
+    public final List<MemoItem> memos;
+
+    public HandoverMemosResponse(LocalDate date, List<MemoItem> memos) {
+        this.date = date;
+        this.memoCount = memos.size();
+        this.memos = memos;
+    }
+
+    public static MemoItem toItem(HandoverMemo memo) {
+        return new MemoItem(
+                memo.getMemoId(),
+                memo.getContent(),
+                new CreatedBy(
+                        memo.getCreatedBy().getUserId(),
+                        memo.getCreatedBy().getName()
+                ),
+                memo.getCreatedAt()
+        );
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+
+    public record MemoItem(
+            Long memoId,
+            String content,
+            CreatedBy createdBy,
+            LocalDateTime createdAt
+    ) {
+    }
+
+    public record CreatedBy(Long userId, String name) {
+    }
+}

--- a/src/main/java/com/better/CommuteMate/task/controller/dtos/UpdateAdminTodoRequest.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/dtos/UpdateAdminTodoRequest.java
@@ -1,0 +1,16 @@
+package com.better.CommuteMate.task.controller.dtos;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateAdminTodoRequest(
+        @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "업무사항 입력값이 올바르지 않습니다.")
+        String date,
+
+        @Pattern(regexp = "(?:[01]\\d|2[0-3]):[0-5]\\d", message = "업무사항 입력값이 올바르지 않습니다.")
+        String timeSlot,
+
+        @Size(max = 200, message = "업무사항 입력값이 올바르지 않습니다.")
+        String description
+) {
+}

--- a/src/main/java/com/better/CommuteMate/task/controller/dtos/UpdateAdminTodoResponse.java
+++ b/src/main/java/com/better/CommuteMate/task/controller/dtos/UpdateAdminTodoResponse.java
@@ -1,0 +1,39 @@
+package com.better.CommuteMate.task.controller.dtos;
+
+import com.better.CommuteMate.domain.task.entity.Task;
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class UpdateAdminTodoResponse extends ResponseDetail {
+    public final Long todoId;
+    public final LocalDate date;
+    public final LocalTime timeSlot;
+    public final String description;
+    public final String status;
+    public final boolean completed;
+    public final LocalDateTime updatedAt;
+
+    private UpdateAdminTodoResponse(Task task) {
+        this.todoId = task.getTaskId();
+        this.date = task.getTaskDate();
+        this.timeSlot = task.getTaskTime();
+        this.description = task.getTitle();
+        this.completed = Boolean.TRUE.equals(task.getIsCompleted());
+        this.status = completed ? "COMPLETED" : "PENDING";
+        this.updatedAt = task.getUpdatedAt();
+    }
+
+    public static UpdateAdminTodoResponse from(Task task) {
+        return new UpdateAdminTodoResponse(task);
+    }
+
+    @Override
+    @JsonIgnore
+    public LocalDateTime getTimestamp() {
+        return super.getTimestamp();
+    }
+}

--- a/src/test/java/com/better/CommuteMate/home/application/AdminHomeServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/home/application/AdminHomeServiceTest.java
@@ -1,0 +1,148 @@
+package com.better.CommuteMate.home.application;
+
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
+import com.better.CommuteMate.domain.task.entity.Task;
+import com.better.CommuteMate.domain.task.repository.TaskRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.workattendance.entity.WorkAttendance;
+import com.better.CommuteMate.domain.workattendance.repository.WorkAttendanceRepository;
+import com.better.CommuteMate.global.code.CodeType;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.home.controller.dto.AdminAttendanceSummaryResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminHomeServiceTest {
+
+    @Mock
+    private WorkSchedulesRepository scheduleRepository;
+
+    @Mock
+    private WorkAttendanceRepository attendanceRepository;
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Test
+    void returnsAttendanceAndTaskSummary() {
+        AdminHomeService service = new AdminHomeService(
+                scheduleRepository,
+                attendanceRepository,
+                taskRepository
+        );
+        LocalDate date = LocalDate.of(2026, 4, 15);
+        LocalTime start = LocalTime.of(9, 0);
+
+        User workingUser = user(1L);
+        User notCheckedInUser = user(2L);
+        User completedUser = user(3L);
+        WorkSchedule workingSchedule = schedule(11L, workingUser, date, start);
+        WorkSchedule notCheckedInSchedule = schedule(12L, notCheckedInUser, date, start);
+        WorkSchedule completedSchedule = schedule(13L, completedUser, date, start);
+        List<WorkSchedule> schedules = List.of(
+                workingSchedule,
+                notCheckedInSchedule,
+                completedSchedule
+        );
+
+        WorkAttendance lateCheckIn = attendance(
+                workingSchedule,
+                CodeType.CT01,
+                LocalDateTime.of(date, start.plusMinutes(11))
+        );
+        WorkAttendance onTimeCheckIn = attendance(
+                completedSchedule,
+                CodeType.CT01,
+                LocalDateTime.of(date, start.plusMinutes(10))
+        );
+        WorkAttendance checkOut = attendance(
+                completedSchedule,
+                CodeType.CT02,
+                LocalDateTime.of(date, start.plusHours(3))
+        );
+        List<WorkAttendance> attendances = List.of(lateCheckIn, onTimeCheckIn, checkOut);
+        List<Task> tasks = List.of(
+                Task.builder().isCompleted(true).build(),
+                Task.builder().isCompleted(false).build()
+        );
+
+        when(scheduleRepository.findAllByUser_OrganizationIdAndDateAndStatusCode(
+                10L, date, CodeType.WS02
+        )).thenReturn(schedules);
+        when(attendanceRepository.findAllByScheduleIn(schedules)).thenReturn(attendances);
+        when(taskRepository.findAllByAssignee_OrganizationIdAndTaskDate(10L, date))
+                .thenReturn(tasks);
+
+        AdminAttendanceSummaryResponse response =
+                service.getAttendanceSummary(10L, "2026-04-15");
+
+        assertThat(response.date).isEqualTo(date);
+        assertThat(response.currentWorkingCount).isEqualTo(1);
+        assertThat(response.notCheckedInCount).isEqualTo(1);
+        assertThat(response.lateCount).isEqualTo(1);
+        assertThat(response.todayTask.completedCount()).isEqualTo(1);
+        assertThat(response.todayTask.totalCount()).isEqualTo(2);
+    }
+
+    @Test
+    void rejectsInvalidDate() {
+        AdminHomeService service = new AdminHomeService(
+                scheduleRepository,
+                attendanceRepository,
+                taskRepository
+        );
+
+        assertThatThrownBy(() -> service.getAttendanceSummary(10L, "2026-02-30"))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("조회 날짜 값이 올바르지 않습니다.");
+    }
+
+    private User user(Long userId) {
+        return User.builder()
+                .userId(userId)
+                .organizationId(10L)
+                .build();
+    }
+
+    private WorkSchedule schedule(
+            Long scheduleId,
+            User user,
+            LocalDate date,
+            LocalTime start
+    ) {
+        return WorkSchedule.builder()
+                .scheduleId(scheduleId)
+                .user(user)
+                .date(date)
+                .startTime(start)
+                .endTime(start.plusHours(3))
+                .statusCode(CodeType.WS02)
+                .build();
+    }
+
+    private WorkAttendance attendance(
+            WorkSchedule schedule,
+            CodeType checkType,
+            LocalDateTime checkTime
+    ) {
+        return WorkAttendance.builder()
+                .schedule(schedule)
+                .user(schedule.getUser())
+                .checkTypeCode(checkType)
+                .checkTime(checkTime)
+                .build();
+    }
+}

--- a/src/test/java/com/better/CommuteMate/task/application/AdminTodoServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/task/application/AdminTodoServiceTest.java
@@ -6,6 +6,7 @@ import com.better.CommuteMate.domain.user.entity.User;
 import com.better.CommuteMate.domain.user.repository.UserRepository;
 import com.better.CommuteMate.global.exceptions.CustomException;
 import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoRequest;
+import com.better.CommuteMate.task.controller.dtos.UpdateAdminTodoRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +17,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -93,6 +95,88 @@ class AdminTodoServiceTest {
         verify(taskRepository).save(captor.capture());
         assertThat(captor.getValue().getCreatedBy()).isEqualTo(7L);
         assertThat(captor.getValue().getTitle()).isEqualTo("Newspaper pickup");
+    }
+
+    @Test
+    void updatesOnlyProvidedTodoFields() {
+        User admin = User.builder().userId(7L).organizationId(10L).build();
+        User creator = User.builder().userId(8L).organizationId(10L).build();
+        Task task = Task.builder()
+                .taskId(3L)
+                .title("기존 업무")
+                .taskDate(LocalDate.of(2026, 4, 14))
+                .taskTime(LocalTime.of(9, 0))
+                .isCompleted(false)
+                .createdBy(8L)
+                .updatedAt(LocalDateTime.of(2026, 4, 15, 10, 40))
+                .build();
+        when(taskRepository.findById(3L)).thenReturn(Optional.of(task));
+        when(userRepository.findById(7L)).thenReturn(Optional.of(admin));
+        when(userRepository.findById(8L)).thenReturn(Optional.of(creator));
+        when(taskRepository.saveAndFlush(task)).thenReturn(task);
+
+        var response = service.updateTodo(
+                3L,
+                new UpdateAdminTodoRequest(null, "14:00", " 회의실 청소 "),
+                7L
+        );
+
+        assertThat(response.todoId).isEqualTo(3L);
+        assertThat(response.date).isEqualTo(LocalDate.of(2026, 4, 14));
+        assertThat(response.timeSlot).isEqualTo(LocalTime.of(14, 0));
+        assertThat(response.description).isEqualTo("회의실 청소");
+        assertThat(response.status).isEqualTo("PENDING");
+        assertThat(task.getUpdatedBy()).isEqualTo(7L);
+        verify(taskRepository).saveAndFlush(task);
+    }
+
+    @Test
+    void rejectsEmptyUpdateRequest() {
+        User admin = User.builder().userId(7L).organizationId(10L).build();
+        User creator = User.builder().userId(8L).organizationId(10L).build();
+        Task task = Task.builder().taskId(3L).createdBy(8L).build();
+        when(taskRepository.findById(3L)).thenReturn(Optional.of(task));
+        when(userRepository.findById(7L)).thenReturn(Optional.of(admin));
+        when(userRepository.findById(8L)).thenReturn(Optional.of(creator));
+
+        assertThatThrownBy(() -> service.updateTodo(
+                3L,
+                new UpdateAdminTodoRequest(null, null, null),
+                7L
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("업무사항 입력값이 올바르지 않습니다.");
+    }
+
+    @Test
+    void rejectsUpdateFromAnotherOrganization() {
+        User admin = User.builder().userId(7L).organizationId(10L).build();
+        User creator = User.builder().userId(8L).organizationId(20L).build();
+        Task task = Task.builder().taskId(3L).createdBy(8L).build();
+        when(taskRepository.findById(3L)).thenReturn(Optional.of(task));
+        when(userRepository.findById(7L)).thenReturn(Optional.of(admin));
+        when(userRepository.findById(8L)).thenReturn(Optional.of(creator));
+
+        assertThatThrownBy(() -> service.updateTodo(
+                3L,
+                new UpdateAdminTodoRequest(null, "14:00", null),
+                7L
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("업무사항을 수정할 권한이 없습니다.");
+    }
+
+    @Test
+    void rejectsMissingTodo() {
+        when(taskRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateTodo(
+                999L,
+                new UpdateAdminTodoRequest(null, "14:00", null),
+                7L
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("업무사항을 찾을 수 없습니다.");
     }
 
     private Task task(Long id, String title, LocalTime time, boolean completed, Long createdBy) {

--- a/src/test/java/com/better/CommuteMate/task/application/AdminTodoServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/task/application/AdminTodoServiceTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import org.mockito.ArgumentCaptor;
 
 @ExtendWith(MockitoExtension.class)
@@ -177,6 +178,35 @@ class AdminTodoServiceTest {
         ))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("업무사항을 찾을 수 없습니다.");
+    }
+
+    @Test
+    void deletesTodoCreatedInSameOrganization() {
+        User admin = User.builder().userId(7L).organizationId(10L).build();
+        User creator = User.builder().userId(8L).organizationId(10L).build();
+        Task task = Task.builder().taskId(3L).createdBy(8L).build();
+        when(taskRepository.findById(3L)).thenReturn(Optional.of(task));
+        when(userRepository.findById(7L)).thenReturn(Optional.of(admin));
+        when(userRepository.findById(8L)).thenReturn(Optional.of(creator));
+
+        service.deleteTodo(3L, 7L);
+
+        verify(taskRepository).delete(task);
+    }
+
+    @Test
+    void rejectsDeleteFromAnotherOrganization() {
+        User admin = User.builder().userId(7L).organizationId(10L).build();
+        User creator = User.builder().userId(8L).organizationId(20L).build();
+        Task task = Task.builder().taskId(3L).createdBy(8L).build();
+        when(taskRepository.findById(3L)).thenReturn(Optional.of(task));
+        when(userRepository.findById(7L)).thenReturn(Optional.of(admin));
+        when(userRepository.findById(8L)).thenReturn(Optional.of(creator));
+
+        assertThatThrownBy(() -> service.deleteTodo(3L, 7L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("업무사항을 삭제할 권한이 없습니다.");
+        verify(taskRepository, never()).delete(task);
     }
 
     private Task task(Long id, String title, LocalTime time, boolean completed, Long createdBy) {

--- a/src/test/java/com/better/CommuteMate/task/application/AdminTodoServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/task/application/AdminTodoServiceTest.java
@@ -5,6 +5,7 @@ import com.better.CommuteMate.domain.task.repository.TaskRepository;
 import com.better.CommuteMate.domain.user.entity.User;
 import com.better.CommuteMate.domain.user.repository.UserRepository;
 import com.better.CommuteMate.global.exceptions.CustomException;
+import com.better.CommuteMate.task.controller.dtos.CreateAdminTodoRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +20,9 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import org.mockito.ArgumentCaptor;
 
 @ExtendWith(MockitoExtension.class)
 class AdminTodoServiceTest {
@@ -62,6 +66,33 @@ class AdminTodoServiceTest {
         assertThatThrownBy(() -> service.getTodos(10L, "2026/04/15"))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("날짜 형식이 올바르지 않습니다.");
+    }
+
+    @Test
+    void createsPendingTodo() {
+        Task saved = Task.builder()
+                .taskId(3L)
+                .title("Newspaper pickup")
+                .taskDate(LocalDate.of(2026, 4, 15))
+                .taskTime(LocalTime.of(9, 0))
+                .isCompleted(false)
+                .createdBy(7L)
+                .createdAt(LocalDateTime.of(2026, 4, 15, 8, 30))
+                .build();
+        when(taskRepository.save(any(Task.class))).thenReturn(saved);
+
+        var response = service.createTodo(
+                new CreateAdminTodoRequest("2026-04-15", "09:00", "Newspaper pickup"),
+                7L
+        );
+
+        assertThat(response.todoId).isEqualTo(3L);
+        assertThat(response.status).isEqualTo("PENDING");
+        assertThat(response.completed).isFalse();
+        ArgumentCaptor<Task> captor = ArgumentCaptor.forClass(Task.class);
+        verify(taskRepository).save(captor.capture());
+        assertThat(captor.getValue().getCreatedBy()).isEqualTo(7L);
+        assertThat(captor.getValue().getTitle()).isEqualTo("Newspaper pickup");
     }
 
     private Task task(Long id, String title, LocalTime time, boolean completed, Long createdBy) {

--- a/src/test/java/com/better/CommuteMate/task/application/AdminTodoServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/task/application/AdminTodoServiceTest.java
@@ -1,0 +1,80 @@
+package com.better.CommuteMate.task.application;
+
+import com.better.CommuteMate.domain.task.entity.Task;
+import com.better.CommuteMate.domain.task.repository.TaskRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminTodoServiceTest {
+
+    @Mock TaskRepository taskRepository;
+    @Mock UserRepository userRepository;
+
+    private AdminTodoService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminTodoService(taskRepository, userRepository);
+    }
+
+    @Test
+    void returnsTodosSeparatedAtNoonWithUiCompletionFields() {
+        LocalDate date = LocalDate.of(2026, 4, 15);
+        User creator = User.builder().userId(7L).name("홍길동").build();
+        Task morning = task(1L, "신문지 가져오기", LocalTime.of(9, 0), true, 7L);
+        Task afternoon = task(2L, "회의실 청소", LocalTime.of(14, 0), false, 7L);
+        when(taskRepository.findAdminTodos(10L, date)).thenReturn(List.of(morning, afternoon));
+        when(userRepository.findAllById(List.of(7L))).thenReturn(List.of(creator));
+
+        var response = service.getTodos(10L, "2026-04-15");
+
+        assertThat(response.date).isEqualTo(date);
+        assertThat(response.morningTodos).singleElement().satisfies(todo -> {
+            assertThat(todo.todoId()).isEqualTo(1L);
+            assertThat(todo.description()).isEqualTo("신문지 가져오기");
+            assertThat(todo.status()).isEqualTo("COMPLETED");
+            assertThat(todo.createdBy().name()).isEqualTo("홍길동");
+            assertThat(todo.completedByName()).isEqualTo("홍길동");
+            assertThat(todo.completedTime()).isEqualTo(LocalTime.of(9, 13));
+        });
+        assertThat(response.afternoonTodos).singleElement()
+                .extracting(todo -> todo.status()).isEqualTo("PENDING");
+    }
+
+    @Test
+    void rejectsInvalidDateFormat() {
+        assertThatThrownBy(() -> service.getTodos(10L, "2026/04/15"))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("날짜 형식이 올바르지 않습니다.");
+    }
+
+    private Task task(Long id, String title, LocalTime time, boolean completed, Long createdBy) {
+        return Task.builder()
+                .taskId(id)
+                .title(title)
+                .taskDate(LocalDate.of(2026, 4, 15))
+                .taskTime(time)
+                .isCompleted(completed)
+                .createdBy(createdBy)
+                .createdAt(LocalDateTime.of(2026, 4, 15, 8, 30))
+                .completedByName(completed ? "홍길동" : null)
+                .completedTime(completed ? LocalTime.of(9, 13) : null)
+                .build();
+    }
+}

--- a/src/test/java/com/better/CommuteMate/task/application/HandoverMemoServiceTest.java
+++ b/src/test/java/com/better/CommuteMate/task/application/HandoverMemoServiceTest.java
@@ -1,0 +1,64 @@
+package com.better.CommuteMate.task.application;
+
+import com.better.CommuteMate.domain.handovermemo.entity.HandoverMemo;
+import com.better.CommuteMate.domain.handovermemo.repository.HandoverMemoRepository;
+import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.global.exceptions.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HandoverMemoServiceTest {
+
+    @Mock HandoverMemoRepository handoverMemoRepository;
+
+    private HandoverMemoService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new HandoverMemoService(handoverMemoRepository);
+    }
+
+    @Test
+    void returnsOrganizationMemosForRequestedDate() {
+        User creator = User.builder().userId(7L).name("홍길동").build();
+        HandoverMemo memo = HandoverMemo.builder()
+                .memoId(1L)
+                .organizationId(10L)
+                .content("다음 근무자가 쓰레기봉투 꼭 갈아주세요.")
+                .createdBy(creator)
+                .createdAt(LocalDateTime.of(2026, 4, 15, 10, 36))
+                .build();
+        when(handoverMemoRepository.findDailyMemos(
+                10L,
+                LocalDateTime.of(2026, 4, 15, 0, 0),
+                LocalDateTime.of(2026, 4, 16, 0, 0)
+        )).thenReturn(List.of(memo));
+
+        var response = service.getMemos(10L, "2026-04-15");
+
+        assertThat(response.memoCount).isEqualTo(1);
+        assertThat(response.memos).singleElement().satisfies(item -> {
+            assertThat(item.memoId()).isEqualTo(1L);
+            assertThat(item.createdBy().userId()).isEqualTo(7L);
+            assertThat(item.createdBy().name()).isEqualTo("홍길동");
+        });
+    }
+
+    @Test
+    void rejectsInvalidDateFormat() {
+        assertThatThrownBy(() -> service.getMemos(10L, "2026/04/15"))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("날짜 형식이 올바르지 않습니다.");
+    }
+}


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix를 사용합니다.
feat: 새로운 기능 추가
fix: 버그 수정
docs: 문서 수정
style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
refactor: 코드 리팩토링
test: 테스트 코드 추가, 리팩토링
chore: 빌드 부분 혹은 패키지 매니저 설정 변경
-->

## 1. 요약 📝
관리자 업무사항 조회 및 관리 API를 구현했습니다.
## 2. 관련 이슈 🔗
- 일별 업무사항 조회 API 구현
- 인수인계 메모 조회 API 구현
- 업무사항 추가 API 구현
- 업무사항 부분 수정 API 구현
- 업무사항 삭제 API 구현
## 3. 주요 변경 사항 🔑

## 4. 기타 💬
