### PR TITLE
feat: 마이페이지 조회 API 구현 및 신청 기간 외 근무 신청 차단

### DIFF
--- a/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
+++ b/src/main/java/com/better/CommuteMate/global/exceptions/error/ScheduleErrorCode.java
@@ -36,7 +36,8 @@ public enum ScheduleErrorCode implements CustomErrorCode {
     EDIT_REQUEST_EMPTY("수정 요청 항목이 없습니다.", "[Error] : 수정 요청 항목 없음", HttpStatus.BAD_REQUEST),
     EDIT_REQUEST_REASON_REQUIRED("수정 요청 사유를 입력해야 합니다.", "[Error] : 수정 요청 사유 미입력", HttpStatus.BAD_REQUEST),
     DELETE_SCHEDULE_NOT_FOUND("삭제 요청한 스케줄을 찾을 수 없습니다.", "[Error] : 삭제 요청 스케줄 미존재", HttpStatus.NOT_FOUND),
-    CROSS_WEEK_RANGE_NOT_ALLOWED("조회 기간은 같은 주 이내여야 합니다.", "[Error] : 다른 주에 걸친 조회 범위", HttpStatus.BAD_REQUEST);
+    CROSS_WEEK_RANGE_NOT_ALLOWED("조회 기간은 같은 주 이내여야 합니다.", "[Error] : 다른 주에 걸친 조회 범위", HttpStatus.BAD_REQUEST),
+    APPLY_PERIOD_NOT_ACTIVE("근로 신청 기간이 아닙니다.", "[Error] : 근로 신청 기간 외 신청 시도", HttpStatus.BAD_REQUEST);
 
 
     private final String message;

--- a/src/main/java/com/better/CommuteMate/mypage/application/MyPageService.java
+++ b/src/main/java/com/better/CommuteMate/mypage/application/MyPageService.java
@@ -5,14 +5,24 @@ import com.better.CommuteMate.domain.faq.entity.FaqStatus;
 import com.better.CommuteMate.domain.faq.repository.FaqRepository;
 import com.better.CommuteMate.domain.organization.entity.Organization;
 import com.better.CommuteMate.domain.organization.repository.OrganizationRepository;
+import com.better.CommuteMate.domain.schedule.entity.WorkSchedule;
+import com.better.CommuteMate.domain.schedule.entity.WorkScheduleSetting;
+import com.better.CommuteMate.domain.schedule.repository.WorkSchedulesRepository;
 import com.better.CommuteMate.domain.user.entity.User;
+import com.better.CommuteMate.domain.user.entity.UserProfile;
+import com.better.CommuteMate.domain.user.repository.UserProfileRepository;
 import com.better.CommuteMate.domain.user.repository.UserRepository;
+import com.better.CommuteMate.domain.workattendance.repository.WorkAttendanceRepository;
+import com.better.CommuteMate.global.code.CodeType;
 import com.better.CommuteMate.global.exceptions.CustomException;
 import com.better.CommuteMate.global.exceptions.error.GlobalErrorCode;
 import com.better.CommuteMate.global.exceptions.error.OrganizationErrorCode;
+import com.better.CommuteMate.global.util.WorkWeekUtils;
 import com.better.CommuteMate.mypage.dto.GetMyFaqListResponse;
 import com.better.CommuteMate.mypage.dto.GetMyFaqListWrapper;
 import com.better.CommuteMate.mypage.dto.GetMyPageResponse;
+import com.better.CommuteMate.mypage.dto.MyPageInfoResponse;
+import com.better.CommuteMate.schedule.application.WorkScheduleSettingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,7 +31,14 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +47,80 @@ public class MyPageService {
     private final UserRepository userRepository;
     private final FaqRepository faqRepository;
     private final OrganizationRepository organizationRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final WorkSchedulesRepository workSchedulesRepository;
+    private final WorkAttendanceRepository workAttendanceRepository;
+    private final WorkScheduleSettingService workScheduleSettingService;
+
+    public MyPageInfoResponse getMyPageInfo(Long userId, Long organizationId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> CustomException.of(GlobalErrorCode.USER_NOT_FOUND));
+
+        Organization organization = organizationRepository.findById(organizationId)
+                .orElseThrow(() -> CustomException.of(OrganizationErrorCode.ORGANIZATION_NOT_FOUND));
+
+        UserProfile profile = userProfileRepository.findById(userId).orElse(null);
+
+        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
+
+        LocalDate weekStart = WorkWeekUtils.weekStart(today);
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        YearMonth yearMonth = YearMonth.from(today);
+        LocalDate monthStart = yearMonth.atDay(1);
+        LocalDate monthEnd = yearMonth.atEndOfMonth();
+
+        List<WorkSchedule> weekSlots = workSchedulesRepository
+                .findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(userId, weekStart, weekEnd, CodeType.WS04);
+        List<WorkSchedule> monthSlots = workSchedulesRepository
+                .findAllByUser_UserIdAndDateBetweenAndStatusCodeNot(userId, monthStart, monthEnd, CodeType.WS04);
+
+        Set<Long> weekCheckedInIds = workAttendanceRepository.findAllByScheduleIn(weekSlots).stream()
+                .filter(a -> a.getCheckTypeCode() == CodeType.CT01)
+                .map(a -> a.getSchedule().getScheduleId())
+                .collect(Collectors.toSet());
+        Set<Long> monthCheckedInIds = workAttendanceRepository.findAllByScheduleIn(monthSlots).stream()
+                .filter(a -> a.getCheckTypeCode() == CodeType.CT01)
+                .map(a -> a.getSchedule().getScheduleId())
+                .collect(Collectors.toSet());
+
+        long weekWorkedMinutes = weekSlots.stream()
+                .filter(s -> weekCheckedInIds.contains(s.getScheduleId())
+                        && LocalDateTime.of(s.getDate(), s.getEndTime()).isBefore(now))
+                .mapToLong(s -> Duration.between(s.getStartTime(), s.getEndTime()).toMinutes())
+                .sum();
+        long monthWorkedMinutes = monthSlots.stream()
+                .filter(s -> monthCheckedInIds.contains(s.getScheduleId())
+                        && LocalDateTime.of(s.getDate(), s.getEndTime()).isBefore(now))
+                .mapToLong(s -> Duration.between(s.getStartTime(), s.getEndTime()).toMinutes())
+                .sum();
+
+        Optional<WorkScheduleSetting> settingOpt =
+                workScheduleSettingService.getSetting(organizationId, today.getYear(), today.getMonthValue());
+        int weekLimitHours = settingOpt
+                .map(s -> s.getWeeklyMaxMinutes() != null ? s.getWeeklyMaxMinutes() / 60 : 0)
+                .orElse(0);
+        int monthLimitHours = settingOpt
+                .map(s -> s.getMonthlyRequiredMinutes() != null ? s.getMonthlyRequiredMinutes() / 60 : 0)
+                .orElse(0);
+
+        return MyPageInfoResponse.builder()
+                .userName(user.getName())
+                .roleName(user.getRoleCode().getCodeValue())
+                .organizationName(organization.getName())
+                .department(profile != null ? profile.getDepartment() : null)
+                .studentId(profile != null ? profile.getStudentId() : null)
+                .week(MyPageInfoResponse.PeriodHours.builder()
+                        .workedHours((int) (weekWorkedMinutes / 60))
+                        .limitHours(weekLimitHours)
+                        .build())
+                .month(MyPageInfoResponse.PeriodHours.builder()
+                        .workedHours((int) (monthWorkedMinutes / 60))
+                        .limitHours(monthLimitHours)
+                        .build())
+                .build();
+    }
 
     public GetMyPageResponse getMyPage(Long userId) {
 

--- a/src/main/java/com/better/CommuteMate/mypage/controller/MyPageV1Controller.java
+++ b/src/main/java/com/better/CommuteMate/mypage/controller/MyPageV1Controller.java
@@ -1,0 +1,84 @@
+package com.better.CommuteMate.mypage.controller;
+
+import com.better.CommuteMate.auth.application.CustomUserDetails;
+import com.better.CommuteMate.global.controller.dtos.Response;
+import com.better.CommuteMate.mypage.application.MyPageService;
+import com.better.CommuteMate.mypage.dto.MyPageInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "마이페이지", description = "마이페이지 정보 조회 API")
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class MyPageV1Controller {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    @Operation(
+            summary = "마이페이지 조회",
+            description = """
+                    인증된 사용자의 프로필 정보와 이번 주 및 이번 달 근무 시간 현황을 조회합니다.
+                    - roleName은 코드 표시값(학생/관리자)을 그대로 반환합니다.
+                    - UserProfile이 미등록된 경우 department와 studentId는 null로 응답됩니다.
+                    - week.workedHours / month.workedHours는 실제 근무가 완료된 시간입니다 (CT01 출근 기록 존재 + 슬롯 종료 시각 경과 기준).
+                    - week.limitHours는 monthly_setting의 weekly_max_minutes를 시간 환산한 값이며, 설정이 없으면 0입니다.
+                    - month.limitHours는 monthly_required_minutes를 시간 환산한 값이며, 설정이 없으면 0입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "마이페이지 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "조회 성공",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "message": "마이페이지 정보를 조회했습니다.",
+                                              "details": {
+                                                "userName": "홍길동",
+                                                "roleName": "학생",
+                                                "organizationName": "건국대학교 정보운영팀",
+                                                "department": "컴퓨터공학과",
+                                                "studentId": "202412345",
+                                                "week": {
+                                                  "workedHours": 3,
+                                                  "limitHours": 13
+                                                },
+                                                "month": {
+                                                  "workedHours": 13,
+                                                  "limitHours": 27
+                                                }
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content)
+    })
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Response> getMyPageInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        Long organizationId = userDetails.getUser().getOrganizationId();
+        MyPageInfoResponse response = myPageService.getMyPageInfo(userId, organizationId);
+        return ResponseEntity.ok(Response.of(true, "마이페이지 정보를 조회했습니다.", response));
+    }
+}

--- a/src/main/java/com/better/CommuteMate/mypage/dto/MyPageInfoResponse.java
+++ b/src/main/java/com/better/CommuteMate/mypage/dto/MyPageInfoResponse.java
@@ -1,0 +1,64 @@
+package com.better.CommuteMate.mypage.dto;
+
+import com.better.CommuteMate.global.controller.dtos.ResponseDetail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyPageInfoResponse extends ResponseDetail {
+
+    @Schema(description = "사용자 이름", example = "홍길동")
+    private String userName;
+
+    @Schema(description = "역할 표시명", example = "학생")
+    private String roleName;
+
+    @Schema(description = "소속 조직명", example = "건국대학교 정보운영팀")
+    private String organizationName;
+
+    @Schema(description = "학과명 (프로필 미등록 시 null)", example = "컴퓨터공학과", nullable = true)
+    private String department;
+
+    @Schema(description = "학번 (프로필 미등록 시 null)", example = "202412345", nullable = true)
+    private String studentId;
+
+    @Schema(description = "이번 주 근무 현황")
+    private PeriodHours week;
+
+    @Schema(description = "이번 달 근무 현황")
+    private PeriodHours month;
+
+    @Builder
+    public MyPageInfoResponse(String userName, String roleName, String organizationName,
+                               String department, String studentId,
+                               PeriodHours week, PeriodHours month) {
+        super();
+        this.userName = userName;
+        this.roleName = roleName;
+        this.organizationName = organizationName;
+        this.department = department;
+        this.studentId = studentId;
+        this.week = week;
+        this.month = month;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class PeriodHours {
+
+        @Schema(description = "완료된 근무 시간 (시간 단위)", example = "3")
+        private int workedHours;
+
+        @Schema(description = "근무 한도 시간 (시간 단위)", example = "13")
+        private int limitHours;
+
+        @Builder
+        public PeriodHours(int workedHours, int limitHours) {
+            this.workedHours = workedHours;
+            this.limitHours = limitHours;
+        }
+    }
+}

--- a/src/main/java/com/better/CommuteMate/schedule/application/ScheduleService.java
+++ b/src/main/java/com/better/CommuteMate/schedule/application/ScheduleService.java
@@ -289,14 +289,14 @@ public class ScheduleService {
                 slot.date().getMonthValue()
         );
 
+        if (!setting.isApplyPeriod(LocalDateTime.now())) {
+            throw CustomException.of(ScheduleErrorCode.APPLY_PERIOD_NOT_ACTIVE);
+        }
+
         if (!scheduleValidator.isScheduleInsertable(slot, setting)) {
             failure.add(toResponseSlot(slot));
             return;
         }
-
-        CodeType statusCode = setting.isApplyPeriod(LocalDateTime.now())
-                ? CodeType.WS02
-                : CodeType.WS01;
 
         WorkSchedule workSchedule = WorkSchedule.builder()
                 .user(user)
@@ -305,7 +305,7 @@ public class ScheduleService {
                 .date(slot.date())
                 .startTime(slot.start())
                 .endTime(slot.end())
-                .statusCode(statusCode)
+                .statusCode(CodeType.WS02)
                 .createdBy(String.valueOf(user.getUserId()))
                 .updatedBy(String.valueOf(user.getUserId()))
                 .build();
@@ -314,13 +314,11 @@ public class ScheduleService {
 
         success.add(toResponseSlot(slot));
 
-        if (statusCode.equals(CodeType.WS02)) {
-            changes.add(new ScheduleChange(
-                    true,
-                    slot.startDateTime(),
-                    slot.endDateTime()
-            ));
-        }
+        changes.add(new ScheduleChange(
+                true,
+                slot.startDateTime(),
+                slot.endDateTime()
+        ));
     }
 
     /**

--- a/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
+++ b/src/main/java/com/better/CommuteMate/schedule/controller/schedule/WorkScheduleController.java
@@ -74,6 +74,11 @@ public class WorkScheduleController {
                                     {"isSuccess":false,"message":"신청하신 일정이 모두 실패하였습니다.","details":{"success":[],"failure":[{"start":"2026-04-07T09:00:00","end":"2026-04-07T10:00:00"}]}}
                                     """)
                     })),
+            @ApiResponse(responseCode = "400", description = "근로 신청 기간 외 요청",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {"isSuccess":false,"message":"근로 신청 기간이 아닙니다.","details":null}
+                                    """))),
             @ApiResponse(responseCode = "404", description = "해당 연월의 스케줄 설정 없음",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = """


### PR DESCRIPTION
## 1. 요약 📝

마이페이지 조회 API를 구현하고, 신청 기간 밖에서 근무 신청 시 영구 대기 상태 행이 쌓이던 문제를 수정

## 2. 관련 이슈 🔗

<!-- 예: close #00 -->

## 3. 주요 변경 사항 🔑

**마이페이지 조회 — `GET /api/v1/mypage`**
- 사용자 프로필 정보(이름, 역할, 소속 조직명, 학과, 학번)와 이번 주/이번 달 근무 시간 현황 반환
- `workedHours`는 실제 근무가 완료된 시간만 합산 — 해당 슬롯에 출근(CT01) 기록이 있고 근무 종료 시각이 경과한 경우(WK03 기준)
- `limitHours`는 `work_schedule_setting`의 주별 최대 근무시간 / 월별 필수 근무시간 기준
- `UserProfile`이 없는 사용자도 정상 응답하도록 null 처리
- 배치 조회로 N+1 방지 (주/월 슬롯 조회 + 출근 기록 조회)
- Swagger 명세 작성, `@SecurityRequirement(name = "JWT")` 적용

**신청 기간 외 근무 신청 차단**
- 신청 기간(`applyEnabled` + `applyStartAt~applyEndAt`) 밖에서 `addSlot()`을 호출하면 WS01(대기) 상태로 저장되지만, WS02로 전환하는 경로가 코드베이스에 존재하지 않아 영구 대기 행이 쌓이는 문제가 있었습니다.
- `addSlot()`에 `setting.isApplyPeriod()` 검증을 추가해 기간 외 신청은 400으로 거부
- `statusCode` 삼항 분기(WS02 : WS01) 제거 → 항상 WS02로 저장
- `ScheduleErrorCode`에 `APPLY_PERIOD_NOT_ACTIVE` 추가
- `POST /api/v1/work-schedules/apply` Swagger에 400 응답 케이스 추가

## 4. 기타 💬

- 이번 변경은 최초 신청(`apply`) 경로에만 적용됩니다. 수정 요청(`edit`)은 `work_change_request`(CS 코드)로 관리되는 별도 경로이며 영향받지 않습니다.
- 수정 요청(`submitEditRequest`)에는 기간 검증과 `edit_enabled` 컬럼 확인이 없어, 지난 달 시간표에도 수정 요청이 가능한 상태입니다. 별도 작업으로 분리해 처리할 예정입니다.
